### PR TITLE
fix(keycardai-mcp-fastmcp): lock the oauth dependency

### DIFF
--- a/packages/mcp-fastmcp/pyproject.toml
+++ b/packages/mcp-fastmcp/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
     "pydantic>=2.11.7",
     "pydantic-settings>=2.7.1",
     "httpx>=0.27.2",
-    "keycardai-oauth",
+    "keycardai-oauth>=0.4.1,<1.0.0",
     "fastmcp==2.12.0",
 ]
 keywords = ["fastmcp", "mcp", "model-context-protocol", "oauth", "token-exchange", "authentication", "keycard"]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 
 [manifest]
@@ -7,6 +7,7 @@ members = [
     "keycardai",
     "keycardai-mcp",
     "keycardai-mcp-fastmcp",
+    "keycardai-mcp-slack",
     "keycardai-oauth",
 ]
 
@@ -863,6 +864,24 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "fastmcp", specifier = "==2.12.0" },
+    { name = "httpx", specifier = ">=0.27.2" },
+    { name = "keycardai-oauth", editable = "packages/oauth" },
+    { name = "pydantic", specifier = ">=2.11.7" },
+    { name = "pydantic-settings", specifier = ">=2.7.1" },
+]
+
+[[package]]
+name = "keycardai-mcp-slack"
+source = { editable = "packages/mcp-slack" }
+dependencies = [
+    { name = "httpx" },
+    { name = "keycardai-oauth" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+]
+
+[package.metadata]
+requires-dist = [
     { name = "httpx", specifier = ">=0.27.2" },
     { name = "keycardai-oauth", editable = "packages/oauth" },
     { name = "pydantic", specifier = ">=2.11.7" },


### PR DESCRIPTION
The package requires latest auth strategies. 