### PR TITLE
fix(keycardai-mcp): support x-forwarded-port header

### DIFF
--- a/packages/mcp/src/keycardai/mcp/server/middleware/bearer.py
+++ b/packages/mcp/src/keycardai/mcp/server/middleware/bearer.py
@@ -7,11 +7,12 @@ from starlette.responses import Response
 from starlette.types import ASGIApp
 
 from ..auth.verifier import TokenVerifier
+from ..shared.starlette import get_base_url
 
 
 def _get_oauth_protected_resource_url(request: Request) -> str:
     path = request.url.path.lstrip("/").rstrip("/")
-    base_url = str(request.base_url).rstrip("/")
+    base_url = get_base_url(request)
     return str(AnyHttpUrl(f"{base_url}/.well-known/oauth-protected-resource/{path}"))
 
 def _get_bearer_token(request: Request) -> str | None:

--- a/packages/mcp/src/keycardai/mcp/server/shared/starlette.py
+++ b/packages/mcp/src/keycardai/mcp/server/shared/starlette.py
@@ -1,0 +1,22 @@
+"""Shared utilities for Starlette/FastAPI applications."""
+
+from pydantic import AnyHttpUrl
+from starlette.requests import Request
+
+"""Supported protocols for the base URL."""
+SUPPORTED_PROTOCOLS = ["http", "https"]
+
+
+def get_base_url(request: Request) -> str:
+    """Get the correct base URL considering proxy headers like X-Forwarded-Proto."""
+    request_base_url = AnyHttpUrl(str(request.base_url))
+    proto = request.headers.get("x-forwarded-proto") or request_base_url.scheme
+    if proto not in SUPPORTED_PROTOCOLS:
+        proto = "https"
+
+    if request_base_url.port not in [443, 80]:
+        base_url = f"{proto}://{request_base_url.host}:{request_base_url.port}"
+    else:
+        base_url = f"{proto}://{request_base_url.host}"
+
+    return base_url

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 
 [manifest]
@@ -7,6 +7,7 @@ members = [
     "keycardai",
     "keycardai-mcp",
     "keycardai-mcp-fastmcp",
+    "keycardai-mcp-slack",
     "keycardai-oauth",
 ]
 
@@ -883,6 +884,41 @@ requires-dist = [
     { name = "fastmcp", specifier = "==2.12.0" },
     { name = "httpx", specifier = ">=0.27.2" },
     { name = "keycardai-mcp", editable = "packages/mcp" },
+    { name = "keycardai-oauth", editable = "packages/oauth" },
+    { name = "pydantic", specifier = ">=2.11.7" },
+    { name = "pydantic-settings", specifier = ">=2.7.1" },
+    { name = "pytest", marker = "extra == 'test'", specifier = ">=8.4.1" },
+    { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=1.1.0" },
+]
+provides-extras = ["test"]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest-cov", specifier = ">=6.2.1" }]
+
+[[package]]
+name = "keycardai-mcp-slack"
+source = { editable = "packages/mcp-slack" }
+dependencies = [
+    { name = "httpx" },
+    { name = "keycardai-oauth" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+]
+
+[package.optional-dependencies]
+test = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest-cov" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "httpx", specifier = ">=0.27.2" },
     { name = "keycardai-oauth", editable = "packages/oauth" },
     { name = "pydantic", specifier = ">=2.11.7" },
     { name = "pydantic-settings", specifier = ">=2.7.1" },


### PR DESCRIPTION
Metadata endpoint did not include the forwarded port in the returned headers. 