### PR TITLE
feat(keycardai-mcp): enable custom middleware injection

### DIFF
--- a/packages/mcp/src/keycardai/mcp/server/auth/provider.py
+++ b/packages/mcp/src/keycardai/mcp/server/auth/provider.py
@@ -10,6 +10,7 @@ from mcp.server.auth.settings import AuthSettings
 from mcp.server.fastmcp import Context, FastMCP
 from pydantic import AnyHttpUrl
 from starlette.applications import Starlette
+from starlette.middleware import Middleware
 from starlette.routing import Route
 from starlette.types import ASGIApp
 
@@ -629,7 +630,7 @@ class AuthProvider:
             jwks=self.jwks
         )
 
-    def app(self, mcp_app: FastMCP) -> ASGIApp:
+    def app(self, mcp_app: FastMCP, middleware: list[Middleware] | None = None) -> ASGIApp:
         """Get the MCP app with authentication middleware and metadata endpoints."""
         @contextlib.asynccontextmanager
         async def lifespan(app: Starlette):
@@ -639,4 +640,5 @@ class AuthProvider:
         return Starlette(
             routes=self.get_mcp_router(mcp_app.streamable_http_app()),
             lifespan=lifespan,
+            middleware=middleware,
         )

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10"
 
 [manifest]
@@ -7,6 +7,7 @@ members = [
     "keycardai",
     "keycardai-mcp",
     "keycardai-mcp-fastmcp",
+    "keycardai-mcp-slack",
     "keycardai-oauth",
 ]
 
@@ -883,6 +884,41 @@ requires-dist = [
     { name = "fastmcp", specifier = "==2.12.0" },
     { name = "httpx", specifier = ">=0.27.2" },
     { name = "keycardai-mcp", editable = "packages/mcp" },
+    { name = "keycardai-oauth", editable = "packages/oauth" },
+    { name = "pydantic", specifier = ">=2.11.7" },
+    { name = "pydantic-settings", specifier = ">=2.7.1" },
+    { name = "pytest", marker = "extra == 'test'", specifier = ">=8.4.1" },
+    { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=1.1.0" },
+]
+provides-extras = ["test"]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest-cov", specifier = ">=6.2.1" }]
+
+[[package]]
+name = "keycardai-mcp-slack"
+source = { editable = "packages/mcp-slack" }
+dependencies = [
+    { name = "httpx" },
+    { name = "keycardai-oauth" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+]
+
+[package.optional-dependencies]
+test = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest-cov" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "httpx", specifier = ">=0.27.2" },
     { name = "keycardai-oauth", editable = "packages/oauth" },
     { name = "pydantic", specifier = ">=2.11.7" },
     { name = "pydantic-settings", specifier = ">=2.7.1" },


### PR DESCRIPTION
This adds ability to inject custom middleware into the server

For example
```
middleware = [
    Middleware(CORSMiddleware, allow_methods=['*'], allow_origins=['*'], allow_headers=['*'])
]
app = auth.app(mcp, middleware=middleware)
```