### PR TITLE
feat(keycardai-mcp-fastmcp): ability to mock internal access contex

### DIFF
--- a/packages/mcp-fastmcp/src/keycardai/mcp/integrations/fastmcp/__init__.py
+++ b/packages/mcp-fastmcp/src/keycardai/mcp/integrations/fastmcp/__init__.py
@@ -66,7 +66,6 @@ Advanced Configuration:
     )
 """
 
-# Re-export commonly used auth strategies for convenience
 from keycardai.mcp.server.auth.client_factory import ClientFactory, DefaultClientFactory
 from keycardai.mcp.server.exceptions import (
     # Specific exceptions
@@ -88,6 +87,7 @@ from keycardai.oauth.http.auth import (
 )
 
 from .provider import AccessContext, AuthProvider
+from .testing import mock_access_context
 
 __all__ = [
     # Core classes
@@ -115,4 +115,7 @@ __all__ = [
     "ResourceAccessError",
     "TokenExchangeError",
     "MetadataDiscoveryError",
+
+    # Testing utilities
+    "mock_access_context",
 ]

--- a/packages/mcp-fastmcp/src/keycardai/mcp/integrations/fastmcp/testing/__init__.py
+++ b/packages/mcp-fastmcp/src/keycardai/mcp/integrations/fastmcp/testing/__init__.py
@@ -1,0 +1,36 @@
+"""Testing utilities for FastMCP integration with Keycard authentication.
+
+This module provides mock implementations and utilities for testing FastMCP servers
+that use Keycard authentication without requiring real OAuth flows or network calls.
+
+Components:
+- mock_access_context: Context manager for mocking authentication in tests
+
+Example:
+    from keycardai.mcp.integrations.fastmcp.testing import mock_access_context
+
+    # Test successful authentication with default token
+    with mock_access_context():
+        # Your test code here - will return "test_access_token" for any resource
+
+    # Test with specific access token
+    with mock_access_context(access_token="my_custom_token"):
+        # Your test code here - will return "my_custom_token" for any resource
+
+    # Test with resource-specific tokens
+    with mock_access_context(resource_tokens={
+        "https://api.example.com": "token_123",
+        "https://api.other.com": "token_456"
+    }):
+        # Your test code here - will return specific tokens for each resource
+
+    # Test error scenarios
+    with mock_access_context(has_errors=True, error_message="Auth failed"):
+        # Your test code here - access_context.has_errors() will return True
+"""
+
+from .test_utils import mock_access_context
+
+__all__ = [
+    "mock_access_context",
+]

--- a/packages/mcp-fastmcp/src/keycardai/mcp/integrations/fastmcp/testing/test_utils.py
+++ b/packages/mcp-fastmcp/src/keycardai/mcp/integrations/fastmcp/testing/test_utils.py
@@ -1,0 +1,98 @@
+from contextlib import contextmanager
+from unittest.mock import Mock, patch
+
+from keycardai.oauth.types.models import TokenResponse
+
+
+@contextmanager
+def mock_access_context(
+    access_token: str = "test_access_token",
+    resource_tokens: dict[str, str] | None = None,
+    has_errors: bool = False,
+    error_message: str = "Mock authentication error",
+):
+    """Mock the authentication system for testing.
+
+    Args:
+        access_token: Default access token to return for any resource (str)
+        resource_tokens: Dict mapping resource URLs to specific access tokens (dict[str, str])
+        has_errors: Whether the access context should report errors (bool)
+        error_message: Error message to return when has_errors=True (str)
+
+    Examples:
+        # 1. Default - always returns access token
+        with mock_access_context():
+            # Will return "test_access_token" for any resource
+
+        # 2. Returns access token for provided resource
+        with mock_access_context(access_token="my_token"):
+            # Will return "my_token" for any resource
+
+        # 3. Return access token for provided dict of resources
+        with mock_access_context(resource_tokens={
+            "https://api.example.com": "token_123",
+            "https://api.other.com": "token_456"
+        }):
+            # Will return specific tokens for each resource
+            # Any resource not in the dict will set has_errors=True with "Resource not granted" message
+
+        # 4. Returns error set to true and error message
+        with mock_access_context(has_errors=True, error_message="Auth failed"):
+            # Will report errors with the specified message
+    """
+    with patch('keycardai.mcp.integrations.fastmcp.provider.AccessContext') as mock_access_context_class, \
+         patch('keycardai.mcp.integrations.fastmcp.provider.get_access_token') as mock_get_access_token:
+
+        mock_access_context_instance = Mock()
+        mock_access_context_instance.has_errors.return_value = has_errors
+
+        if has_errors:
+            # Return proper error structure matching AccessContext.get_errors()
+            mock_access_context_instance.get_errors.return_value = {
+                "resource_errors": {},
+                "error": {"error": error_message}
+            }
+            mock_access_context_instance.access.side_effect = Exception(error_message)
+        else:
+            def mock_access_method(resource_url):
+                if resource_tokens is not None:
+                    if resource_url in resource_tokens:
+                        # Return proper TokenResponse object
+                        return TokenResponse(
+                            access_token=resource_tokens[resource_url],
+                            token_type="Bearer"
+                        )
+                    else:
+                        # Resource not granted - set error state and raise exception
+                        mock_access_context_instance.has_errors.return_value = True
+                        mock_access_context_instance.get_errors.return_value = {
+                            "resource_errors": {
+                                resource_url: {"error": f"Resource not granted: {resource_url}"}
+                            },
+                            "error": None
+                        }
+                        from keycardai.mcp.server.exceptions import ResourceAccessError
+                        raise ResourceAccessError()
+                else:
+                    # Return proper TokenResponse object
+                    return TokenResponse(
+                        access_token=access_token,
+                        token_type="Bearer"
+                    )
+
+            mock_access_context_instance.access = mock_access_method
+            mock_access_context_instance.get_errors.return_value = {
+                "resource_errors": {},
+                "error": None
+            }
+
+        mock_access_context_instance.set_bulk_tokens = Mock()
+        mock_access_context_instance.set_error = Mock()
+        mock_access_context_instance.set_resource_error = Mock()
+        mock_access_context_class.return_value = mock_access_context_instance
+
+        mock_user_token = Mock()
+        mock_user_token.token = "user_jwt_token"
+        mock_get_access_token.return_value = mock_user_token
+
+        yield mock_access_context_instance


### PR DESCRIPTION
Adds ability to mock the internal access context. Required for testing of mcp servers with authentication and delegation enabled. 