### PR TITLE
fix: add examples as workspace members for standalone execution

### DIFF
--- a/packages/mcp-fastmcp/examples/delegated_access/README.md
+++ b/packages/mcp-fastmcp/examples/delegated_access/README.md
@@ -112,14 +112,6 @@ uv run python main.py
 
 The server will start on `http://localhost:8000`.
 
-> **Local SDK development:** If you're working on the Keycard SDK packages locally and want to run this example against your local changes, run from the repository root instead:
->
-> ```bash
-> uv run --package delegated-access-example python packages/mcp-fastmcp/examples/delegated_access/main.py
-> ```
->
-> This uses the root workspace to resolve all SDK packages from source.
-
 ### 5. Verify the Server
 
 Check that OAuth metadata is being served:

--- a/packages/mcp-fastmcp/examples/delegated_access/README.md
+++ b/packages/mcp-fastmcp/examples/delegated_access/README.md
@@ -96,26 +96,29 @@ Use the public URL from your tunnel as `MCP_SERVER_URL`.
 ### 2. Set Environment Variables
 
 ```bash
-export KEYCARD_ZONE_ID="your-zone-id"
+export KEYCARD_ZONE_ID="your-zone-id"          # or use KEYCARD_ZONE_URL
 export KEYCARD_CLIENT_ID="your-client-id"
 export KEYCARD_CLIENT_SECRET="your-client-secret"
 export MCP_SERVER_URL="https://your-tunnel-url.ngrok.io/"  # Must be publicly reachable
 ```
 
-### 3. Install Dependencies
+### 3. Install Dependencies and Run the Server
 
 ```bash
 cd packages/mcp-fastmcp/examples/delegated_access
 uv sync
-```
-
-### 4. Run the Server
-
-```bash
 uv run python main.py
 ```
 
 The server will start on `http://localhost:8000`.
+
+> **Local SDK development:** If you're working on the Keycard SDK packages locally and want to run this example against your local changes, run from the repository root instead:
+>
+> ```bash
+> uv run --package delegated-access-example python packages/mcp-fastmcp/examples/delegated_access/main.py
+> ```
+>
+> This uses the root workspace to resolve all SDK packages from source.
 
 ### 5. Verify the Server
 
@@ -176,10 +179,13 @@ The example demonstrates comprehensive error handling patterns:
 
 | Variable | Required | Description |
 |----------|----------|-------------|
-| `KEYCARD_ZONE_ID` | Yes | Your Keycard zone ID |
+| `KEYCARD_ZONE_ID` | Yes* | Your Keycard zone ID |
+| `KEYCARD_ZONE_URL` | Yes* | Your full Keycard zone URL (alternative to `KEYCARD_ZONE_ID`) |
 | `KEYCARD_CLIENT_ID` | Yes | Client ID from application credentials |
 | `KEYCARD_CLIENT_SECRET` | Yes | Client secret from application credentials |
 | `MCP_SERVER_URL` | Yes | Server URL (must be publicly reachable for delegated access) |
+
+\* Provide either `KEYCARD_ZONE_ID` or `KEYCARD_ZONE_URL`, not both.
 
 ## Learn More
 

--- a/packages/mcp-fastmcp/examples/delegated_access/main.py
+++ b/packages/mcp-fastmcp/examples/delegated_access/main.py
@@ -19,16 +19,15 @@ from fastmcp import Context, FastMCP
 from keycardai.mcp.integrations.fastmcp import AccessContext, AuthProvider, ClientSecret
 
 # Configure Keycard authentication with client credentials for delegated access
-# Get your zone_id and client credentials from console.keycard.ai
+# Set KEYCARD_ZONE_ID (or KEYCARD_ZONE_URL) and client credentials from console.keycard.ai
 auth_provider = AuthProvider(
-    zone_id=os.getenv("KEYCARD_ZONE_ID", "your-zone-id"),
     mcp_server_name="GitHub API Server",
     mcp_base_url=os.getenv("MCP_SERVER_URL", "http://localhost:8000/"),
     # ClientSecret enables token exchange for delegated access
     application_credential=ClientSecret(
         (
-            os.getenv("KEYCARD_CLIENT_ID", "your-client-id"),
-            os.getenv("KEYCARD_CLIENT_SECRET", "your-client-secret"),
+            os.getenv("KEYCARD_CLIENT_ID"),
+            os.getenv("KEYCARD_CLIENT_SECRET"),
         )
     ),
 )

--- a/packages/mcp-fastmcp/examples/delegated_access/main.py
+++ b/packages/mcp-fastmcp/examples/delegated_access/main.py
@@ -21,6 +21,7 @@ from keycardai.mcp.integrations.fastmcp import AccessContext, AuthProvider, Clie
 # Configure Keycard authentication with client credentials for delegated access
 # Set KEYCARD_ZONE_ID (or KEYCARD_ZONE_URL) and client credentials from console.keycard.ai
 auth_provider = AuthProvider(
+    zone_id=os.getenv("KEYCARD_ZONE_ID", "your-zone-id"),
     mcp_server_name="GitHub API Server",
     mcp_base_url=os.getenv("MCP_SERVER_URL", "http://localhost:8000/"),
     # ClientSecret enables token exchange for delegated access

--- a/packages/mcp-fastmcp/examples/delegated_access/main.py
+++ b/packages/mcp-fastmcp/examples/delegated_access/main.py
@@ -26,8 +26,8 @@ auth_provider = AuthProvider(
     # ClientSecret enables token exchange for delegated access
     application_credential=ClientSecret(
         (
-            os.getenv("KEYCARD_CLIENT_ID"),
-            os.getenv("KEYCARD_CLIENT_SECRET"),
+            os.getenv("KEYCARD_CLIENT_ID", "your-client-id"),
+            os.getenv("KEYCARD_CLIENT_SECRET", "your-client-secret"),
         )
     ),
 )

--- a/packages/mcp-fastmcp/examples/delegated_access/pyproject.toml
+++ b/packages/mcp-fastmcp/examples/delegated_access/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "delegated-access-example"
+name = "delegated-access-fastmcp-example"
 version = "0.1.0"
 description = "GitHub API integration with Keycard delegated access using the @grant decorator"
 readme = "README.md"

--- a/packages/mcp-fastmcp/pyproject.toml
+++ b/packages/mcp-fastmcp/pyproject.toml
@@ -61,9 +61,6 @@ url = "https://test.pypi.org/simple/"
 publish-url = "https://test.pypi.org/legacy/"
 explicit = true
 
-[tool.uv.sources]
-keycardai-oauth = { workspace = true }
-keycardai-mcp = { workspace = true }
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/keycardai"]

--- a/packages/mcp/examples/delegated_access/pyproject.toml
+++ b/packages/mcp/examples/delegated_access/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "delegated-access-example"
+name = "delegated-access-lowlevel-example"
 version = "0.1.0"
 description = "GitHub API integration with Keycard delegated access using the low-level MCP package"
 readme = "README.md"

--- a/packages/mcp/pyproject.toml
+++ b/packages/mcp/pyproject.toml
@@ -79,10 +79,6 @@ url = "https://test.pypi.org/simple/"
 publish-url = "https://test.pypi.org/legacy/"
 explicit = true
 
-[tool.uv.sources]
-keycardai-oauth = { workspace = true }
-keycardai-mcp-fastmcp = { workspace = true }
-
 [tool.hatch.build.targets.wheel]
 packages = ["src/keycardai"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,8 @@ Issues = "https://github.com/keycardai/python-sdk/issues"
 [tool.uv.workspace]
 members = [
     ".",
-    "packages/*"
+    "packages/*",
+    "packages/*/examples/*"
 ]
 # Exclude any packages that shouldn't be part of the workspace
 exclude = []

--- a/uv.lock
+++ b/uv.lock
@@ -9,11 +9,35 @@ resolution-markers = [
 
 [manifest]
 members = [
+    "a2a-jsonrpc-usage",
+    "client-connection-example",
+    "delegated-access-fastmcp-example",
+    "delegated-access-lowlevel-example",
+    "discover-server-metadata",
+    "dynamic-client-registration",
+    "hello-world-server",
+    "hello-world-server-lowlevel",
     "keycardai",
     "keycardai-agents",
     "keycardai-mcp",
     "keycardai-mcp-fastmcp",
     "keycardai-oauth",
+    "oauth-client-usage",
+]
+
+[[package]]
+name = "a2a-jsonrpc-usage"
+version = "0.1.0"
+source = { virtual = "packages/agents/examples/a2a_jsonrpc_usage" }
+dependencies = [
+    { name = "httpx" },
+    { name = "keycardai-agents" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "httpx", specifier = ">=0.27.2" },
+    { name = "keycardai-agents", editable = "packages/agents" },
 ]
 
 [[package]]
@@ -727,6 +751,21 @@ wheels = [
 ]
 
 [[package]]
+name = "client-connection-example"
+version = "0.1.0"
+source = { virtual = "packages/mcp/examples/client_connection" }
+dependencies = [
+    { name = "keycardai-mcp" },
+    { name = "uvicorn" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "keycardai-mcp", editable = "packages/mcp" },
+    { name = "uvicorn", specifier = ">=0.30.0" },
+]
+
+[[package]]
 name = "cohere"
 version = "5.20.1"
 source = { registry = "https://pypi.org/simple" }
@@ -988,6 +1027,51 @@ wheels = [
 ]
 
 [[package]]
+name = "delegated-access-fastmcp-example"
+version = "0.1.0"
+source = { virtual = "packages/mcp-fastmcp/examples/delegated_access" }
+dependencies = [
+    { name = "fastmcp" },
+    { name = "httpx" },
+    { name = "keycardai-mcp-fastmcp" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "fastmcp", specifier = ">=3.0.0" },
+    { name = "httpx", specifier = ">=0.27.0,<1.0.0" },
+    { name = "keycardai-mcp-fastmcp", editable = "packages/mcp-fastmcp" },
+]
+
+[[package]]
+name = "delegated-access-lowlevel-example"
+version = "0.1.0"
+source = { virtual = "packages/mcp/examples/delegated_access" }
+dependencies = [
+    { name = "httpx" },
+    { name = "keycardai-mcp" },
+    { name = "uvicorn" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "httpx", specifier = ">=0.27.0,<1.0.0" },
+    { name = "keycardai-mcp", editable = "packages/mcp" },
+    { name = "uvicorn", specifier = ">=0.30.0" },
+]
+
+[[package]]
+name = "discover-server-metadata"
+version = "0.1.0"
+source = { virtual = "packages/oauth/examples/discover_server_metadata" }
+dependencies = [
+    { name = "keycardai-oauth" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "keycardai-oauth", editable = "packages/oauth" }]
+
+[[package]]
 name = "diskcache"
 version = "5.6.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1049,6 +1133,17 @@ sdist = { url = "https://files.pythonhosted.org/packages/9d/a4/e44218c2b394e31a6
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b0/0d/9feae160378a3553fa9a339b0e9c1a048e147a4127210e286ef18b730f03/durationpy-0.10-py3-none-any.whl", hash = "sha256:3b41e1b601234296b4fb368338fdcd3e13e0b4fb5b67345948f4f2bf9868b286", size = 3922, upload-time = "2025-05-17T13:52:36.463Z" },
 ]
+
+[[package]]
+name = "dynamic-client-registration"
+version = "0.1.0"
+source = { virtual = "packages/oauth/examples/dynamic_client_registration" }
+dependencies = [
+    { name = "keycardai-oauth" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "keycardai-oauth", editable = "packages/oauth" }]
 
 [[package]]
 name = "email-validator"
@@ -1521,6 +1616,36 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "hello-world-server"
+version = "0.1.0"
+source = { virtual = "packages/mcp-fastmcp/examples/hello_world_server" }
+dependencies = [
+    { name = "fastmcp" },
+    { name = "keycardai-mcp-fastmcp" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "fastmcp", specifier = ">=3.0.0" },
+    { name = "keycardai-mcp-fastmcp", editable = "packages/mcp-fastmcp" },
+]
+
+[[package]]
+name = "hello-world-server-lowlevel"
+version = "0.1.0"
+source = { virtual = "packages/mcp/examples/hello_world_server" }
+dependencies = [
+    { name = "keycardai-mcp" },
+    { name = "uvicorn" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "keycardai-mcp", editable = "packages/mcp" },
+    { name = "uvicorn", specifier = ">=0.30.0" },
 ]
 
 [[package]]
@@ -3078,6 +3203,17 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/b8/50/94ccd8a2b141cb50651fddd4f6a48874acb3c91c8f0842b08a6afc4b0b21/numpy-2.3.5-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:63c0e9e7eea69588479ebf4a8a270d5ac22763cc5854e9a7eae952a3908103f7", size = 16729263, upload-time = "2025-11-16T22:52:36.369Z" },
     { url = "https://files.pythonhosted.org/packages/2d/ee/346fa473e666fe14c52fcdd19ec2424157290a032d4c41f98127bfb31ac7/numpy-2.3.5-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:f16417ec91f12f814b10bafe79ef77e70113a2f5f7018640e7425ff979253425", size = 12967213, upload-time = "2025-11-16T22:52:39.38Z" },
 ]
+
+[[package]]
+name = "oauth-client-usage"
+version = "0.1.0"
+source = { virtual = "packages/agents/examples/oauth_client_usage" }
+dependencies = [
+    { name = "keycardai-agents" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "keycardai-agents", editable = "packages/agents" }]
 
 [[package]]
 name = "oauthlib"


### PR DESCRIPTION
## Summary

Fixes examples so they can be run directly from their directory with `uv run python main.py`.

### Before
```bash
cd packages/mcp-fastmcp/examples/delegated_access
uv run python main.py
# error: keycardai-oauth references a workspace but is not a workspace member
```

### After
```bash
cd packages/mcp-fastmcp/examples/delegated_access
uv run python main.py
# works
```

### What changed

1. **Remove redundant `[tool.uv.sources]`** from `packages/mcp-fastmcp/pyproject.toml` and `packages/mcp/pyproject.toml` — these declared `workspace = true` for sibling packages, which broke resolution when uv loaded them via editable paths outside the workspace context. The root `pyproject.toml` already declares all workspace sources.

2. **Add `packages/*/examples/*` to workspace members** in the root `pyproject.toml` so examples participate in workspace resolution.

3. **Disambiguate duplicate example names** — two `delegated-access-example` projects across mcp and mcp-fastmcp caused a workspace name collision.

4. **Improve delegated_access example** (from Sean's #94) — adds `KEYCARD_ZONE_URL` support, streamlines README.

Tested all 9 examples locally — all resolve and import successfully from their own directory.

## Test plan

- [x] All 9 examples run from their directory with `uv run python main.py`
- [x] Root `uv sync` still resolves correctly
- [x] CI passes