### PR TITLE
feat(keycardai-starlette): emit DeprecationWarning from legacy bearer surface

### DIFF
--- a/packages/starlette/src/keycardai/starlette/middleware/bearer.py
+++ b/packages/starlette/src/keycardai/starlette/middleware/bearer.py
@@ -21,6 +21,7 @@ This module exposes two layers:
 
 from __future__ import annotations
 
+import warnings
 from collections.abc import Callable, Sequence
 
 from pydantic import AnyHttpUrl
@@ -293,7 +294,10 @@ def keycard_on_error(conn: HTTPConnection, exc: Exception) -> Response:
 
 
 async def verify_bearer_token(
-    request: Request, verifier: TokenVerifier
+    request: Request,
+    verifier: TokenVerifier,
+    *,
+    _from_middleware: bool = False,
 ) -> dict[str, str | None] | Response:
     """Verify the request's bearer token.
 
@@ -305,6 +309,15 @@ async def verify_bearer_token(
         Kept for ``BearerAuthMiddleware`` compatibility. New code should rely
         on ``KeycardAuthBackend``.
     """
+    if not _from_middleware:
+        warnings.warn(
+            "verify_bearer_token is deprecated and will be removed in a "
+            "future release. Use KeycardAuthBackend(verifier) wired to "
+            "starlette.middleware.authentication.AuthenticationMiddleware; "
+            "results are exposed via request.user / request.auth.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
     if not request.headers.get("Authorization"):
         return _create_auth_challenge_response(
             "invalid_token", "No bearer token provided", request
@@ -366,6 +379,15 @@ class BearerAuthMiddleware(BaseHTTPMiddleware):
     """
 
     def __init__(self, app: ASGIApp, verifier: TokenVerifier):
+        warnings.warn(
+            "BearerAuthMiddleware is deprecated and will be removed in a "
+            "future release. Use "
+            "starlette.middleware.authentication.AuthenticationMiddleware "
+            "with backend=KeycardAuthBackend(verifier) and "
+            "on_error=keycard_on_error.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         super().__init__(app)
         self.verifier = verifier
 
@@ -375,7 +397,9 @@ class BearerAuthMiddleware(BaseHTTPMiddleware):
         if _is_oauth_metadata_path(request.url.path):
             return await call_next(request)
 
-        result = await verify_bearer_token(request, self.verifier)
+        result = await verify_bearer_token(
+            request, self.verifier, _from_middleware=True
+        )
         if isinstance(result, Response):
             return result
         request.state.keycardai_auth_info = result

--- a/packages/starlette/tests/keycardai/starlette/test_deprecation_warnings.py
+++ b/packages/starlette/tests/keycardai/starlette/test_deprecation_warnings.py
@@ -1,0 +1,105 @@
+"""Runtime DeprecationWarning tests for the legacy bearer surface.
+
+The deprecated symbols (`BearerAuthMiddleware`, `verify_bearer_token`)
+are retained as shims so `keycardai-mcp` and `keycardai-agents` keep
+working until they migrate to `KeycardAuthBackend` +
+`AuthenticationMiddleware`. Until those migrations land, downstream
+users importing the deprecated symbols should see a runtime warning
+pointing at the replacement.
+"""
+
+import warnings
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from starlette.applications import Starlette
+from starlette.middleware import Middleware
+from starlette.responses import PlainTextResponse
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+from keycardai.starlette.middleware.bearer import (
+    BearerAuthMiddleware,
+    verify_bearer_token,
+)
+
+
+def _stub_verifier() -> MagicMock:
+    token = MagicMock(token="verified-token", client_id="test-client", scopes=[])
+    return MagicMock(
+        enable_multi_zone=False,
+        verify_token=AsyncMock(return_value=token),
+        verify_token_for_zone=AsyncMock(return_value=token),
+    )
+
+
+def test_bearer_auth_middleware_init_warns():
+    with pytest.warns(
+        DeprecationWarning,
+        match=r"BearerAuthMiddleware.*KeycardAuthBackend",
+    ):
+        BearerAuthMiddleware(MagicMock(), _stub_verifier())
+
+
+@pytest.mark.asyncio
+async def test_verify_bearer_token_call_warns():
+    """Direct external call to verify_bearer_token fires the warning.
+
+    The warning fires before any request introspection; catch it explicitly
+    so post-warning failures (the MagicMock request not satisfying pydantic
+    URL parsing) don't mask the assertion under test.
+    """
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        try:
+            await verify_bearer_token(MagicMock(), _stub_verifier())
+        except Exception:
+            pass
+
+    matches = [
+        w
+        for w in caught
+        if issubclass(w.category, DeprecationWarning)
+        and "verify_bearer_token" in str(w.message)
+        and "KeycardAuthBackend" in str(w.message)
+    ]
+    assert len(matches) == 1, f"Expected exactly one warning, got {matches}"
+
+
+def test_middleware_dispatch_does_not_double_warn():
+    """A single BearerAuthMiddleware instance must fire exactly one warning.
+
+    The internal `dispatch` path must call `verify_bearer_token` with
+    `_from_middleware=True` so the per-request flow does not emit a second
+    warning beyond the one fired at middleware construction.
+    """
+    async def endpoint(request):
+        return PlainTextResponse("ok")
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        app = Starlette(
+            routes=[Route("/api/me", endpoint)],
+            middleware=[Middleware(BearerAuthMiddleware, verifier=_stub_verifier())],
+        )
+        client = TestClient(app, raise_server_exceptions=False)
+        client.get("/api/me", headers={"Authorization": "Bearer some-token"})
+
+    bearer_warnings = [
+        w
+        for w in caught
+        if issubclass(w.category, DeprecationWarning)
+        and "BearerAuthMiddleware" in str(w.message)
+    ]
+    verify_warnings = [
+        w
+        for w in caught
+        if issubclass(w.category, DeprecationWarning)
+        and "verify_bearer_token" in str(w.message)
+    ]
+    assert len(bearer_warnings) == 1, (
+        f"Expected exactly one BearerAuthMiddleware warning, got {len(bearer_warnings)}"
+    )
+    assert verify_warnings == [], (
+        f"verify_bearer_token must not warn when called from dispatch; got {verify_warnings}"
+    )


### PR DESCRIPTION
## Summary

Closes ACC-234. PR #97 retained `BearerAuthMiddleware` and `verify_bearer_token` as docstring-only deprecated shims so `keycardai-mcp` and `keycardai-agents` keep working until they migrate (ACC-235, ACC-229..232). Without a runtime signal, non-MCP downstream users importing these symbols get no notice before the symbols disappear.

This adds a runtime `DeprecationWarning` at the two user-facing entry points pointing at the replacement API.

### Changes

- `BearerAuthMiddleware.__init__` emits `DeprecationWarning` pointing at `AuthenticationMiddleware` + `KeycardAuthBackend`
- `verify_bearer_token` emits `DeprecationWarning` pointing at `KeycardAuthBackend`
- `BearerAuthMiddleware.dispatch` passes `_from_middleware=True` to `verify_bearer_token` so a single middleware instantiation fires exactly one warning total (at construction), not one per request

`_create_auth_challenge_response` is intentionally not warned: underscored, not in `__all__`, not re-exported by the keycardai-mcp shims, so no external caller can plausibly hit it directly.

### Removal

The shims and these warnings get removed in the same release as ACC-235 (migrate keycardai-mcp off `BearerAuthMiddleware`).

## Test plan

- [x] 3 new tests in `packages/starlette/tests/keycardai/starlette/test_deprecation_warnings.py`
  - `BearerAuthMiddleware.__init__` fires the warning
  - Direct `verify_bearer_token` call fires the warning
  - Regression: `BearerAuthMiddleware.dispatch` does not double-warn per request
- [x] starlette suite: 49 → 52 passing
- [x] `keycardai-mcp` suite still passes 560/560 with the new warning live
- [x] Manual smoke: `python -W default::DeprecationWarning -c "... BearerAuthMiddleware(...)"` prints the warning at the user's call site (stacklevel=2 correct)
- [x] ruff clean

Note: `keycardai-agents` tests fail on a pre-existing `a2a-sdk>=0.3.22` constraint resolving to 1.0.x (which moved `A2AStarletteApplication` out of `a2a.server.apps.jsonrpc`). Unrelated to this change.