### PR TITLE
fix(keycardai-agents): restore test suite (ACC-236)

### DIFF
--- a/packages/agents/pyproject.toml
+++ b/packages/agents/pyproject.toml
@@ -14,7 +14,11 @@ dependencies = [
     "pydantic>=2.11.7",
     "httpx>=0.27.2",
     "authlib>=1.3.0",  # For JWT signature verification (used by keycardai-oauth)
-    "a2a-sdk>=0.3.22",  # A2A Protocol types and utilities
+    # Pinned <1.0 because a2a-sdk 1.0 moved A2AStarletteApplication out of
+    # a2a.server.apps.jsonrpc, which keycardai-agents/server/app.py imports.
+    # The replacement keycardai-a2a package (ACC-230) will be written against
+    # a2a-sdk 1.x natively; this pin unblocks the agents test suite until then.
+    "a2a-sdk>=0.3.22,<1.0",
 ]
 keywords = ["agents", "ai", "crewai", "authentication", "authorization", "service", "delegation"]
 classifiers = [

--- a/packages/agents/tests/integrations/test_crewai_a2a.py
+++ b/packages/agents/tests/integrations/test_crewai_a2a.py
@@ -6,13 +6,12 @@ import pytest
 
 pytest.importorskip("crewai")
 
-from keycardai.agents.integrations.crewai_a2a import (
+from keycardai.agents import AgentServiceConfig
+from keycardai.agents.integrations.crewai import (
     _create_delegation_tool,
     create_a2a_tool_for_service,
     get_a2a_tools,
 )
-
-from keycardai.agents import AgentServiceConfig
 
 
 @pytest.fixture
@@ -99,7 +98,7 @@ class TestGetA2ATools:
         # When delegatable_services=None, it should try to discover
         # Currently returns empty list (discovery not implemented)
         with patch(
-            "keycardai.agents.integrations.crewai_a2a.ServiceDiscovery"
+            "keycardai.agents.integrations.crewai.ServiceDiscovery"
         ) as mock_discovery_class:
             mock_discovery = AsyncMock()
             mock_discovery.list_delegatable_services.return_value = []
@@ -254,7 +253,7 @@ class TestDelegationToolExecution:
             call_args = mock_invoke.call_args
             task = call_args[0][1]  # Second positional argument
             assert task["task"] == "Analyze PR"
-            assert "pr_number" in task
+            assert task["inputs"] == {"pr_number": 123}
 
     def test_tool_run_calls_a2a_client(self, service_config):
         """Test tool delegates to A2A client correctly."""
@@ -364,7 +363,7 @@ class TestCreateA2AToolForService:
     ):
         """Test create_a2a_tool_for_service fetches agent card."""
         with patch(
-            "keycardai.agents.integrations.crewai_a2a.ServiceDiscovery"
+            "keycardai.agents.integrations.crewai.ServiceDiscovery"
         ) as mock_discovery_class:
             mock_discovery = AsyncMock()
             mock_discovery.get_service_card.return_value = mock_agent_card
@@ -388,7 +387,7 @@ class TestCreateA2AToolForService:
     async def test_create_tool_for_service(self, service_config, mock_agent_card):
         """Test tool is created correctly from agent card."""
         with patch(
-            "keycardai.agents.integrations.crewai_a2a.ServiceDiscovery"
+            "keycardai.agents.integrations.crewai.ServiceDiscovery"
         ) as mock_discovery_class:
             mock_discovery = AsyncMock()
             mock_discovery.get_service_card.return_value = mock_agent_card

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.15'",
@@ -47,22 +47,18 @@ requires-dist = [
 
 [[package]]
 name = "a2a-sdk"
-version = "1.0.2"
+version = "0.3.26"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "culsans", marker = "python_full_version < '3.13'" },
     { name = "google-api-core" },
-    { name = "googleapis-common-protos" },
     { name = "httpx" },
     { name = "httpx-sse" },
-    { name = "json-rpc" },
-    { name = "packaging" },
     { name = "protobuf" },
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/88/f3/1c312eae0298542eef1a096be378a3ad2d20b171ea0ac6be26b81f542720/a2a_sdk-1.0.2.tar.gz", hash = "sha256:e4ee4dd509894c32c9a6df728319875fa4f049e70ae82476fa447353e3a4b648", size = 375193, upload-time = "2026-04-24T13:50:24.303Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/be/97/a6840e01795b182ce751ca165430d46459927cde9bfab838087cbb24aef7/a2a_sdk-0.3.26.tar.gz", hash = "sha256:44068e2d037afbb07ab899267439e9bc7eaa7ac2af94f1e8b239933c993ad52d", size = 274598, upload-time = "2026-04-09T15:21:13.902Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c9/03/58c92a44e7b94a42614880df2365f074969e47067c4c736e31e855aca2fd/a2a_sdk-1.0.2-py3-none-any.whl", hash = "sha256:4dbc083b6808ee28207ac6daad263360f87612c37b2d06f5521efb530318141c", size = 234302, upload-time = "2026-04-24T13:50:22.412Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/d5/51f4ee1bf3b736add42a542d3c8a3fd3fa85f3d36c17972127defc46c26f/a2a_sdk-0.3.26-py3-none-any.whl", hash = "sha256:754e0573f6d33b225c1d8d51f640efa69cbbed7bdfb06ce9c3540ea9f58d4a91", size = 151016, upload-time = "2026-04-09T15:21:12.35Z" },
 ]
 
 [[package]]
@@ -216,20 +212,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/78/b7/15fb7a9d52e112a25b621c67b69c167805cb1f2ab8f1708a5c490d1b52fe/aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:3b13560160d07e047a93f23aaa30718606493036253d5430887514715b67c9d9", size = 1772072, upload-time = "2026-03-31T22:00:07.494Z" },
     { url = "https://files.pythonhosted.org/packages/7e/df/57ba7f0c4a553fc2bd8b6321df236870ec6fd64a2a473a8a13d4f733214e/aiohttp-3.13.5-cp314-cp314t-win32.whl", hash = "sha256:9a0f4474b6ea6818b41f82172d799e4b3d29e22c2c520ce4357856fced9af2f8", size = 471819, upload-time = "2026-03-31T22:00:10.277Z" },
     { url = "https://files.pythonhosted.org/packages/62/29/2f8418269e46454a26171bfdd6a055d74febf32234e474930f2f60a17145/aiohttp-3.13.5-cp314-cp314t-win_amd64.whl", hash = "sha256:18a2f6c1182c51baa1d28d68fea51513cb2a76612f038853c0ad3c145423d3d9", size = 505441, upload-time = "2026-03-31T22:00:12.791Z" },
-]
-
-[[package]]
-name = "aiologic"
-version = "0.16.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "sniffio", marker = "python_full_version < '3.13'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
-    { name = "wrapt", marker = "python_full_version < '3.13'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a8/13/50b91a3ea6b030d280d2654be97c48b6ed81753a50286ee43c646ba36d3c/aiologic-0.16.0.tar.gz", hash = "sha256:c267ccbd3ff417ec93e78d28d4d577ccca115d5797cdbd16785a551d9658858f", size = 225952, upload-time = "2025-11-27T23:48:41.195Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f6/27/206615942005471499f6fbc36621582e24d0686f33c74b2d018fcfd4fe67/aiologic-0.16.0-py3-none-any.whl", hash = "sha256:e00ce5f68c5607c864d26aec99c0a33a83bdf8237aa7312ffbb96805af67d8b6", size = 135193, upload-time = "2025-11-27T23:48:40.099Z" },
 ]
 
 [[package]]
@@ -1125,19 +1107,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/da/9870eec4b69c63ef5925bf7d8342b7e13bc2ee3d47791461c4e49ca212f4/cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:04959522f938493042d595a736e7dbdff6eb6cc2339c11465b3ff89343b65f65", size = 4219115, upload-time = "2026-04-08T01:57:44.939Z" },
     { url = "https://files.pythonhosted.org/packages/f4/72/05aa5832b82dd341969e9a734d1812a6aadb088d9eb6f0430fc337cc5a8f/cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:3986ac1dee6def53797289999eabe84798ad7817f3e97779b5061a95b0ee4968", size = 4385479, upload-time = "2026-04-08T01:57:46.86Z" },
     { url = "https://files.pythonhosted.org/packages/20/2a/1b016902351a523aa2bd446b50a5bc1175d7a7d1cf90fe2ef904f9b84ebc/cryptography-46.0.7-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:258514877e15963bd43b558917bc9f54cf7cf866c38aa576ebf47a77ddbc43a4", size = 3412829, upload-time = "2026-04-08T01:57:48.874Z" },
-]
-
-[[package]]
-name = "culsans"
-version = "0.11.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "aiologic", marker = "python_full_version < '3.13'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/d9/e3/49afa1bc180e0d28008ec6bcdf82a4072d1c7a41032b5b759b60814ca4b0/culsans-0.11.0.tar.gz", hash = "sha256:0b43d0d05dce6106293d114c86e3fb4bfc63088cfe8ff08ed3fe36891447fe33", size = 107546, upload-time = "2025-12-31T23:15:38.196Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/5d/9fb19fb38f6d6120422064279ea5532e22b84aa2be8831d49607194feda3/culsans-0.11.0-py3-none-any.whl", hash = "sha256:278d118f63fc75b9db11b664b436a1b83cc30d9577127848ba41420e66eb5a47", size = 21811, upload-time = "2025-12-31T23:15:37.189Z" },
 ]
 
 [[package]]
@@ -2230,15 +2199,6 @@ wheels = [
 ]
 
 [[package]]
-name = "json-rpc"
-version = "1.15.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6d/9e/59f4a5b7855ced7346ebf40a2e9a8942863f644378d956f68bcef2c88b90/json-rpc-1.15.0.tar.gz", hash = "sha256:e6441d56c1dcd54241c937d0a2dcd193bdf0bdc539b5316524713f554b7f85b9", size = 28854, upload-time = "2023-06-11T09:45:49.078Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/94/9e/820c4b086ad01ba7d77369fb8b11470a01fac9b4977f02e18659cf378b6b/json_rpc-1.15.0-py2.py3-none-any.whl", hash = "sha256:4a4668bbbe7116feb4abbd0f54e64a4adcf4b8f648f19ffa0848ad0f6606a9bf", size = 39450, upload-time = "2023-06-11T09:45:47.136Z" },
-]
-
-[[package]]
 name = "json5"
 version = "0.14.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2404,7 +2364,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "a2a-sdk", specifier = ">=0.3.22" },
+    { name = "a2a-sdk", specifier = ">=0.3.22,<1.0" },
     { name = "authlib", specifier = ">=1.3.0" },
     { name = "crewai", marker = "extra == 'crewai'", specifier = ">=0.86.0" },
     { name = "fastapi", specifier = ">=0.115.0" },


### PR DESCRIPTION
## Summary

Closes ACC-236. Surfaced by ACC-234 wait-and-see verification: `keycardai-agents` tests do not run on a fresh checkout. Three pre-existing breaks fixed:

1. **`a2a-sdk` pinned `<1.0`.** The unbounded `>=0.3.22` resolved to `1.0.x`. `a2a-sdk` 1.0 moved `A2AStarletteApplication` out of `a2a.server.apps.jsonrpc`, which `keycardai-agents/server/app.py` imports. Pinning is the cheap fix because `keycardai-agents` is being decomposed and archived in ACC-229..232; the replacement `keycardai-a2a` (ACC-230) will be written against `a2a-sdk` 1.x natively.
2. **Stale `crewai_a2a` references in tests.** `tests/integrations/test_crewai_a2a.py` imported from `keycardai.agents.integrations.crewai_a2a`, which does not exist (the module is `keycardai.agents.integrations.crewai`). Three import/patch sites updated.
3. **Stale assertion in `test_tool_run_with_task_and_inputs`.** Asserted `"pr_number" in task`; the implementation contract puts `task_inputs` under `task["inputs"]`. Assertion updated to match.

## Test plan

- [x] `cd packages/agents && uv run --extra test pytest` → 85/85 passing
- [x] `cd packages/mcp && uv run --extra test pytest` → 560/560 (unaffected)
- [x] `cd packages/starlette && uv run --extra test pytest` → 49/49 (unaffected)
- [x] `cd packages/oauth && uv run --extra test pytest` → 208/208 (unaffected)
- [x] `uv run ruff check` clean

## Why pin and not upgrade

`keycardai-agents` is being decomposed (ACC-229..232). The replacement `keycardai-a2a` package will adopt `a2a-sdk` 1.x natively. Upgrading the existing package is throwaway work; pinning unblocks the suite cheaply until decomposition lands.