### PR TITLE
feat(keycardai-oauth): add high-level PKCE user-login flow (ACC-229)

### DIFF
--- a/packages/agents/src/keycardai/agents/client/oauth.py
+++ b/packages/agents/src/keycardai/agents/client/oauth.py
@@ -1,165 +1,50 @@
 """User authentication client for calling agent services.
 
-This module provides a client that handles PKCE OAuth flow for user authentication
-when calling protected agent services.
+`AgentClient` invokes A2A agent services and handles 401 responses by running
+the OAuth 2.0 authorization code with PKCE flow against the issuer advertised
+by the resource. The PKCE machinery itself lives in
+:mod:`keycardai.oauth.pkce`; this module is the agent-facing wrapper that
+adds A2A invocation and per-resource token caching.
 """
 
-import asyncio
-import base64
-import hashlib
 import logging
-import re
-import secrets
-import webbrowser
-from http.server import BaseHTTPRequestHandler, HTTPServer
-from threading import Thread
+import warnings
 from typing import Any
-from urllib.parse import parse_qs, urlencode, urlparse
 
 import httpx
+
+from keycardai.oauth.pkce import PKCEClient
 
 from ..config import AgentServiceConfig
 
 logger = logging.getLogger(__name__)
 
 
-class OAuthCallbackServer:
-    """Local HTTP server to handle OAuth callbacks.
-    
-    Starts a temporary HTTP server on localhost to receive the authorization
-    code from the OAuth provider after user authentication.
-    """
-
-    def __init__(self, port: int = 8765):
-        """Initialize callback server.
-        
-        Args:
-            port: Port to listen on (default: 8765)
-        """
-        self.port = port
-        self.code: str | None = None
-        self.error: str | None = None
-        self.server: HTTPServer | None = None
-        self.server_thread: Thread | None = None
-
-    def _create_handler(self):
-        """Create request handler class with access to server instance."""
-        server_instance = self
-
-        class CallbackHandler(BaseHTTPRequestHandler):
-            """HTTP request handler for OAuth callbacks."""
-
-            def log_message(self, format, *args):
-                """Suppress default logging."""
-                pass
-
-            def do_GET(self):
-                """Handle GET request from OAuth provider."""
-                # Parse query parameters
-                parsed = urlparse(self.path)
-                params = parse_qs(parsed.query)
-
-                # Extract code or error
-                if "code" in params:
-                    server_instance.code = params["code"][0]
-                    message = "✅ Authentication successful! You can close this window."
-                    self.send_response(200)
-                elif "error" in params:
-                    server_instance.error = params["error"][0]
-                    error_desc = params.get("error_description", ["Unknown error"])[0]
-                    message = f"❌ Authentication failed: {error_desc}"
-                    self.send_response(400)
-                else:
-                    message = "❌ Invalid callback - missing code or error"
-                    self.send_response(400)
-
-                # Send response
-                self.send_header("Content-type", "text/html")
-                self.end_headers()
-                html = f"""
-                <html>
-                <head><title>OAuth Callback</title></head>
-                <body>
-                    <h1>{message}</h1>
-                    <p>This window will close automatically...</p>
-                    <script>setTimeout(() => window.close(), 2000);</script>
-                </body>
-                </html>
-                """
-                self.wfile.write(html.encode())
-
-        return CallbackHandler
-
-    async def start(self):
-        """Start the callback server in a background thread."""
-        self.server = HTTPServer(("localhost", self.port), self._create_handler())
-        self.server_thread = Thread(target=self.server.serve_forever, daemon=True)
-        self.server_thread.start()
-        logger.debug(f"OAuth callback server started on port {self.port}")
-
-    async def wait_for_code(self, timeout: int = 300) -> str:
-        """Wait for authorization code from callback.
-        
-        Args:
-            timeout: Maximum time to wait in seconds (default: 300 = 5 minutes)
-            
-        Returns:
-            Authorization code
-            
-        Raises:
-            TimeoutError: If code not received within timeout
-            RuntimeError: If OAuth error received
-        """
-        elapsed = 0
-        while elapsed < timeout:
-            if self.code:
-                return self.code
-            if self.error:
-                raise RuntimeError(f"OAuth error: {self.error}")
-            await asyncio.sleep(0.5)
-            elapsed += 0.5
-
-        raise TimeoutError(f"OAuth callback timeout after {timeout}s")
-
-    def stop(self):
-        """Stop the callback server."""
-        if self.server:
-            self.server.shutdown()
-            logger.debug("OAuth callback server stopped")
-
-
 class AgentClient:
     """Client for calling agent services with automatic user authentication.
 
-    This client handles PKCE OAuth flow for user authentication when calling
-    protected agent services. It automatically:
-    1. Detects 401 Unauthorized responses
-    2. Discovers OAuth endpoints from WWW-Authenticate header
-    3. Initiates PKCE flow (opens browser for user login)
-    4. Exchanges authorization code for access token
-    5. Retries the original request with the new token
-    6. Caches tokens for subsequent requests
+    Wraps :class:`keycardai.oauth.pkce.PKCEClient` and adds the A2A specifics:
+    invoking the ``/invoke`` endpoint, retrying on 401 with a fresh token,
+    caching tokens per service URL, and discovering agent cards.
 
-    This is the primary client for users and applications calling agent services.
+    Example::
 
-    Example:
-        >>> from keycardai.agents import AgentServiceConfig
-        >>> from keycardai.agents.client import AgentClient
-        >>> 
-        >>> config = AgentServiceConfig(
-        ...     service_name="My Application",
-        ...     client_id="my_client",
-        ...     client_secret="my_secret",  # Optional for confidential clients
-        ...     identity_url="http://localhost:9000",
-        ...     zone_id="abc123",
-        ... )
-        >>> 
-        >>> async with AgentClient(config) as client:
-        ...     result = await client.invoke(
-        ...         service_url="http://localhost:8001",
-        ...         task="Hello world",
-        ...     )
-        ...     print(result)
+        from keycardai.agents import AgentServiceConfig
+        from keycardai.agents.client import AgentClient
+
+        config = AgentServiceConfig(
+            service_name="My Application",
+            client_id="my_client",
+            client_secret="my_secret",
+            identity_url="http://localhost:9000",
+            zone_id="abc123",
+        )
+
+        async with AgentClient(config) as client:
+            result = await client.invoke(
+                service_url="http://localhost:8001",
+                task="Hello world",
+            )
     """
 
     def __init__(
@@ -169,253 +54,33 @@ class AgentClient:
         callback_port: int = 8765,
         scopes: list[str] | None = None,
     ):
-        """Initialize agent client with OAuth support.
-
-        Args:
-            service_config: Configuration of the calling application
-            redirect_uri: OAuth redirect URI (must be registered with auth server)
-            callback_port: Port for local callback server
-            scopes: Optional list of OAuth scopes to request
-        """
         self.config = service_config
         self.redirect_uri = redirect_uri
         self.callback_port = callback_port
         self.scopes = scopes or []
-        self._token_cache: dict[str, str] = {}  # service_url -> access_token
+        self._token_cache: dict[str, str] = {}
         self.http_client = httpx.AsyncClient(timeout=30.0)
-
-    def _generate_pkce_code_challenge(self, code_verifier: str) -> str:
-        """Generate PKCE code challenge from verifier.
-        
-        Args:
-            code_verifier: Random code verifier string
-            
-        Returns:
-            Base64-URL-encoded SHA256 hash of the verifier
-        """
-        digest = hashlib.sha256(code_verifier.encode()).digest()
-        return base64.urlsafe_b64encode(digest).decode().rstrip("=")
-
-    def _extract_resource_metadata_url(self, www_authenticate: str) -> str | None:
-        """Extract resource metadata URL from WWW-Authenticate header.
-        
-        Args:
-            www_authenticate: Value of WWW-Authenticate header
-            
-        Returns:
-            Resource metadata URL or None if not found
-        """
-        # Parse WWW-Authenticate header for resource_metadata parameter
-        match = re.search(r'resource_metadata="([^"]+)"', www_authenticate)
-        if match:
-            return match.group(1)
-        return None
-
-    async def _fetch_resource_metadata(self, metadata_url: str) -> dict[str, Any]:
-        """Fetch OAuth protected resource metadata.
-        
-        Args:
-            metadata_url: URL to fetch metadata from
-            
-        Returns:
-            Resource metadata dictionary
-            
-        Raises:
-            httpx.HTTPStatusError: If metadata fetch fails
-        """
-        response = await self.http_client.get(metadata_url)
-        response.raise_for_status()
-        return response.json()
-
-    async def _fetch_authorization_server_metadata(
-        self, auth_server_url: str
-    ) -> dict[str, Any]:
-        """Fetch authorization server metadata.
-        
-        Args:
-            auth_server_url: Base URL of authorization server
-            
-        Returns:
-            Authorization server metadata dictionary
-            
-        Raises:
-            httpx.HTTPStatusError: If metadata fetch fails
-        """
-        # Try standard OAuth discovery endpoint
-        discovery_url = f"{auth_server_url.rstrip('/')}/.well-known/oauth-authorization-server"
-        response = await self.http_client.get(discovery_url)
-        response.raise_for_status()
-        return response.json()
+        self._pkce = PKCEClient(
+            client_id=service_config.client_id,
+            client_secret=service_config.client_secret,
+            redirect_uri=redirect_uri,
+            callback_port=callback_port,
+            scopes=self.scopes,
+        )
 
     async def authenticate(
         self,
         service_url: str,
         www_authenticate_header: str,
     ) -> str:
-        """Discover OAuth endpoints and obtain access token via PKCE flow.
-
-        This method:
-        1. Discovers OAuth metadata from WWW-Authenticate header
-        2. Starts local callback server
-        3. Opens browser to authorization endpoint
-        4. Waits for user to authorize
-        5. Exchanges authorization code for access token
-
-        Args:
-            service_url: Base URL of the target service
-            www_authenticate_header: WWW-Authenticate header value from 401 response
-
-        Returns:
-            Access token
-
-        Raises:
-            ValueError: If OAuth discovery fails or metadata is invalid
-            httpx.HTTPStatusError: If token exchange fails
-            TimeoutError: If user doesn't complete authorization in time
-        """
-        logger.info("🔐 OAuth Discovery Flow Started")
-        logger.info(f"   Service URL: {service_url}")
-
-        # Step 1: Extract resource metadata URL
-        metadata_url = self._extract_resource_metadata_url(www_authenticate_header)
-        if not metadata_url:
-            raise ValueError("No resource_metadata URL in WWW-Authenticate header")
-
-        logger.info(f"   Resource metadata URL: {metadata_url}")
-
-        # Step 2: Fetch resource metadata
-        resource_metadata = await self._fetch_resource_metadata(metadata_url)
-        logger.info("   ✅ Resource metadata fetched")
-
-        # Step 3: Get authorization server URL
-        auth_servers = resource_metadata.get("authorization_servers", [])
-        if not auth_servers:
-            raise ValueError("No authorization servers in resource metadata")
-
-        auth_server_url = auth_servers[0]
-        if not auth_server_url.endswith("/"):
-            auth_server_url += "/"
-
-        logger.info(f"   Authorization server: {auth_server_url}")
-
-        # Step 4: Fetch authorization server metadata
-        auth_server_metadata = await self._fetch_authorization_server_metadata(
-            auth_server_url
+        """Run PKCE flow and return the access token, caching it per service."""
+        token_response = await self._pkce.authenticate(
+            resource_url=service_url,
+            www_authenticate_header=www_authenticate_header,
         )
-
-        authorization_endpoint = auth_server_metadata.get("authorization_endpoint")
-        token_endpoint = auth_server_metadata.get("token_endpoint")
-
-        if not authorization_endpoint or not token_endpoint:
-            raise ValueError("Missing authorization_endpoint or token_endpoint in metadata")
-
-        logger.info(f"   Token endpoint: {token_endpoint}")
-        logger.info(f"   Authorization endpoint: {authorization_endpoint}")
-
-        # Step 5: Start local callback server
-        callback_server = OAuthCallbackServer(self.callback_port)
-        await callback_server.start()
-        await asyncio.sleep(0.5)  # Give server time to start
-
-        try:
-            # Step 6: Generate PKCE parameters
-            code_verifier = secrets.token_urlsafe(64)
-            code_challenge = self._generate_pkce_code_challenge(code_verifier)
-            state = secrets.token_urlsafe(32)
-
-            logger.info("🌐 Starting PKCE flow...")
-            logger.info(f"   Redirect URI: {self.redirect_uri}")
-            logger.info(f"   Scopes: {', '.join(self.scopes) if self.scopes else '(none - resource-based authorization)'}")
-
-            # Step 7: Build authorization URL
-            auth_params = {
-                "response_type": "code",
-                "client_id": self.config.client_id,
-                "redirect_uri": self.redirect_uri,
-                "state": state,
-                "code_challenge": code_challenge,
-                "code_challenge_method": "S256",
-                "resource": service_url,  # Request token for base service URL
-            }
-
-            if self.scopes:
-                auth_params["scope"] = " ".join(self.scopes)
-
-            authorization_url = f"{authorization_endpoint}?{urlencode(auth_params)}"
-
-            # Log authorization parameters (for debugging)
-            logger.info("🔗 Authorization URL Parameters:")
-            for key, value in auth_params.items():
-                if key in ["code_challenge", "code_verifier", "state"]:
-                    logger.info(f"   {key}: {value[:20]}...")
-                else:
-                    logger.info(f"   {key}: {value}")
-
-            # Step 8: Open browser for user authentication
-            logger.info("🌐 Opening browser for authentication...")
-            logger.info(f"   Full URL: {authorization_url}")
-            webbrowser.open(authorization_url)
-
-            # Step 9: Wait for authorization code
-            code = await callback_server.wait_for_code()
-            logger.info("✅ Authorization code received!")
-            logger.info(f"   Code (first 20 chars): {code[:20]}...")
-
-            # Step 10: Exchange code for token
-            logger.info("🔄 Exchanging authorization code for access token...")
-
-            token_params = {
-                "grant_type": "authorization_code",
-                "code": code,
-                "redirect_uri": self.redirect_uri,
-                "client_id": self.config.client_id,
-                "code_verifier": code_verifier,
-                "resource": service_url,  # Request token for base service URL
-            }
-
-            # Add client authentication for confidential clients
-            auth_tuple = None
-            if self.config.client_secret:
-                auth_tuple = (self.config.client_id, self.config.client_secret)
-                logger.info("   Client auth: Basic (confidential client)")
-            else:
-                logger.info("   Client auth: None (public client)")
-
-            # Log token exchange parameters (for debugging)
-            logger.info(f"   Token endpoint: {token_endpoint}")
-            logger.info("   Parameters:")
-            for key, value in token_params.items():
-                if key in ["code", "code_verifier"]:
-                    logger.info(f"      {key}: {value[:20]}...")
-                else:
-                    logger.info(f"      {key}: {value}")
-
-            response = await self.http_client.post(
-                token_endpoint,
-                data=token_params,
-                auth=auth_tuple,
-                headers={"Content-Type": "application/x-www-form-urlencoded"},
-            )
-
-            if response.status_code != 200:
-                logger.error(f"Token request failed with status {response.status_code}")
-                logger.error(f"Error response: {response.text}")
-
-            response.raise_for_status()
-            token_data = response.json()
-
-            token = token_data["access_token"]
-            logger.info("✅ Token obtained successfully!")
-            logger.info(f"   Token (first 20 chars): {token[:20]}...")
-
-            # Cache token for future requests
-            self._token_cache[service_url] = token
-
-            return token
-
-        finally:
-            # Always stop callback server
-            callback_server.stop()
+        access_token = token_response["access_token"]
+        self._token_cache[service_url] = access_token
+        return access_token
 
     async def invoke(
         self,
@@ -423,114 +88,78 @@ class AgentClient:
         task: str | dict[str, Any],
         inputs: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
-        """Invoke remote agent service with automatic OAuth handling.
-
-        Calls the /invoke endpoint on the target service. If authentication
-        fails (401), automatically initiates OAuth discovery and PKCE flow.
-
-        Args:
-            service_url: Base URL of the target service (e.g., "http://localhost:8001")
-            task: Task description or parameters
-            inputs: Optional additional inputs
-
-        Returns:
-            Service response (result and delegation_chain)
-
-        Raises:
-            httpx.HTTPStatusError: If request fails (other than auth)
-            ValueError: If OAuth discovery fails
-        """
+        """Call ``/invoke`` on the target service, handling 401 via PKCE flow."""
         invoke_url = f"{service_url.rstrip('/')}/invoke"
+        payload = {"task": task, "inputs": inputs}
 
-        # Prepare request payload
-        payload = {
-            "task": task,
-            "inputs": inputs,
-        }
-
-        # Try cached token first
         token = self._token_cache.get(service_url)
         headers = {}
         if token:
             headers["Authorization"] = f"Bearer {token}"
-            logger.debug(f"Using cached token for {service_url}")
 
-        # Make request
         try:
             response = await self.http_client.post(
-                invoke_url,
-                json=payload,
-                headers=headers,
+                invoke_url, json=payload, headers=headers
+            )
+            response.raise_for_status()
+            return response.json()
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code != 401:
+                raise
+
+            www_authenticate = e.response.headers.get("WWW-Authenticate")
+            if not www_authenticate:
+                logger.error("No WWW-Authenticate header in 401 response")
+                raise
+
+            self._token_cache.pop(service_url, None)
+            new_token = await self.authenticate(service_url, www_authenticate)
+
+            headers["Authorization"] = f"Bearer {new_token}"
+            response = await self.http_client.post(
+                invoke_url, json=payload, headers=headers
             )
             response.raise_for_status()
             return response.json()
 
-        except httpx.HTTPStatusError as e:
-            # If 401, try OAuth discovery
-            if e.response.status_code == 401:
-                logger.info(f"Retry failed with status {e.response.status_code}")
-                logger.info(f"Response headers: {dict(e.response.headers)}")
-                logger.info(f"Response body: {e.response.text}")
-
-                www_authenticate = e.response.headers.get("WWW-Authenticate")
-                if not www_authenticate:
-                    logger.error("No WWW-Authenticate header in 401 response")
-                    raise
-
-                # Clear cached token
-                self._token_cache.pop(service_url, None)
-
-                # Get new token via OAuth discovery
-                try:
-                    new_token = await self.authenticate(
-                        service_url, www_authenticate
-                    )
-                except Exception as oauth_error:
-                    logger.error(f"OAuth discovery/authentication failed: {oauth_error}")
-                    raise
-
-                # Retry with new token
-                headers["Authorization"] = f"Bearer {new_token}"
-                response = await self.http_client.post(
-                    invoke_url,
-                    json=payload,
-                    headers=headers,
-                )
-                response.raise_for_status()
-                return response.json()
-
-            # Re-raise other errors
-            raise
-
     async def discover_service(self, service_url: str) -> dict[str, Any]:
-        """Fetch agent card from remote service.
-
-        Args:
-            service_url: Base URL of the service
-
-        Returns:
-            Agent card dictionary
-
-        Raises:
-            httpx.HTTPStatusError: If request fails
-        """
+        """Fetch the ``.well-known/agent-card.json`` document for a service."""
         card_url = f"{service_url.rstrip('/')}/.well-known/agent-card.json"
         response = await self.http_client.get(card_url)
         response.raise_for_status()
         return response.json()
 
-    async def close(self):
-        """Close HTTP client and cleanup resources."""
+    async def close(self) -> None:
+        await self._pkce.close()
         await self.http_client.aclose()
 
-    async def __aenter__(self):
-        """Async context manager entry."""
+    async def __aenter__(self) -> "AgentClient":
         return self
 
-    async def __aexit__(self, exc_type, exc_val, exc_tb):
-        """Async context manager exit."""
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
         await self.close()
 
 
 # Backward compatibility alias
 A2AServiceClientWithOAuth = AgentClient
+
+
+def __getattr__(name: str):
+    """Deprecation re-export of OAuthCallbackServer.
+
+    The class moved to ``keycardai.oauth.pkce``; this wrapper preserves the old
+    import path with a runtime warning so any direct importer notices.
+    """
+    if name == "OAuthCallbackServer":
+        warnings.warn(
+            "keycardai.agents.client.oauth.OAuthCallbackServer is deprecated; "
+            "import from keycardai.oauth.pkce instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        from keycardai.oauth.pkce import OAuthCallbackServer
+
+        return OAuthCallbackServer
+    raise AttributeError(
+        f"module {__name__!r} has no attribute {name!r}"
+    )

--- a/packages/agents/src/keycardai/agents/client/oauth.py
+++ b/packages/agents/src/keycardai/agents/client/oauth.py
@@ -2,9 +2,9 @@
 
 `AgentClient` invokes A2A agent services and handles 401 responses by running
 the OAuth 2.0 authorization code with PKCE flow against the issuer advertised
-by the resource. The PKCE machinery itself lives in
-:mod:`keycardai.oauth.pkce`; this module is the agent-facing wrapper that
-adds A2A invocation and per-resource token caching.
+by the resource. The PKCE flow itself is :func:`keycardai.oauth.pkce.authenticate`;
+this module is the agent-facing wrapper that adds A2A invocation and
+per-resource token caching.
 """
 
 import logging
@@ -13,7 +13,7 @@ from typing import Any
 
 import httpx
 
-from keycardai.oauth.pkce import PKCEClient
+from keycardai.oauth.pkce import authenticate as pkce_authenticate
 
 from ..config import AgentServiceConfig
 
@@ -23,9 +23,9 @@ logger = logging.getLogger(__name__)
 class AgentClient:
     """Client for calling agent services with automatic user authentication.
 
-    Wraps :class:`keycardai.oauth.pkce.PKCEClient` and adds the A2A specifics:
-    invoking the ``/invoke`` endpoint, retrying on 401 with a fresh token,
-    caching tokens per service URL, and discovering agent cards.
+    Calls :func:`keycardai.oauth.pkce.authenticate` on 401 to obtain a token,
+    caches the token per service URL, and retries the original ``/invoke``
+    request. Also exposes ``discover_service`` for agent-card lookups.
 
     Example::
 
@@ -60,14 +60,6 @@ class AgentClient:
         self.scopes = scopes or []
         self._token_cache: dict[str, str] = {}
         self.http_client = httpx.AsyncClient(timeout=30.0)
-        self._pkce = PKCEClient(
-            client_id=service_config.client_id,
-            client_secret=service_config.client_secret,
-            redirect_uri=redirect_uri,
-            callback_port=callback_port,
-            scopes=self.scopes,
-            http_client=self.http_client,
-        )
 
     async def authenticate(
         self,
@@ -75,13 +67,18 @@ class AgentClient:
         www_authenticate_header: str,
     ) -> str:
         """Run PKCE flow and return the access token, caching it per service."""
-        token_response = await self._pkce.authenticate(
+        token = await pkce_authenticate(
+            client_id=self.config.client_id,
+            client_secret=self.config.client_secret,
             resource_url=service_url,
             www_authenticate_header=www_authenticate_header,
+            redirect_uri=self.redirect_uri,
+            callback_port=self.callback_port,
+            scopes=self.scopes,
+            http_client=self.http_client,
         )
-        access_token = token_response["access_token"]
-        self._token_cache[service_url] = access_token
-        return access_token
+        self._token_cache[service_url] = token.access_token
+        return token.access_token
 
     async def invoke(
         self,
@@ -131,7 +128,6 @@ class AgentClient:
         return response.json()
 
     async def close(self) -> None:
-        await self._pkce.close()
         await self.http_client.aclose()
 
     async def __aenter__(self) -> "AgentClient":

--- a/packages/agents/src/keycardai/agents/client/oauth.py
+++ b/packages/agents/src/keycardai/agents/client/oauth.py
@@ -66,6 +66,7 @@ class AgentClient:
             redirect_uri=redirect_uri,
             callback_port=callback_port,
             scopes=self.scopes,
+            http_client=self.http_client,
         )
 
     async def authenticate(

--- a/packages/agents/tests/test_agent_client_oauth.py
+++ b/packages/agents/tests/test_agent_client_oauth.py
@@ -74,56 +74,6 @@ class TestAgentClientInit:
         assert client.scopes == custom_scopes
 
 
-class TestOAuthDiscoveryMethods:
-    """Test OAuth discovery helper methods."""
-
-    def test_extract_resource_metadata_url(self, service_config, mock_www_authenticate_header):
-        """Test extracting resource_metadata URL from WWW-Authenticate header."""
-        client = AgentClient(service_config)
-        url = client._extract_resource_metadata_url(mock_www_authenticate_header)
-        assert url == "https://protected-service.example.com/.well-known/oauth-protected-resource/invoke"
-
-    def test_extract_resource_metadata_url_missing(self, service_config):
-        """Test handling missing resource_metadata in header."""
-        client = AgentClient(service_config)
-        header = 'Bearer error="invalid_token"'
-        url = client._extract_resource_metadata_url(header)
-        assert url is None
-
-    @pytest.mark.asyncio
-    async def test_fetch_resource_metadata(self, service_config, mock_resource_metadata):
-        """Test fetching OAuth protected resource metadata."""
-        client = AgentClient(service_config)
-        metadata_url = "https://protected-service.example.com/.well-known/oauth-protected-resource"
-
-        with patch.object(client.http_client, "get") as mock_get:
-            mock_response = Mock()
-            mock_response.json.return_value = mock_resource_metadata
-            mock_get.return_value = mock_response
-
-            metadata = await client._fetch_resource_metadata(metadata_url)
-
-            assert metadata == mock_resource_metadata
-            mock_get.assert_called_once_with(metadata_url)
-
-    @pytest.mark.asyncio
-    async def test_fetch_authorization_server_metadata(self, service_config, mock_auth_server_metadata):
-        """Test fetching authorization server metadata."""
-        client = AgentClient(service_config)
-        auth_server_url = "https://test_zone_123.keycard.cloud"
-
-        with patch.object(client.http_client, "get") as mock_get:
-            mock_response = Mock()
-            mock_response.json.return_value = mock_auth_server_metadata
-            mock_get.return_value = mock_response
-
-            metadata = await client._fetch_authorization_server_metadata(auth_server_url)
-
-            assert metadata == mock_auth_server_metadata
-            expected_url = f"{auth_server_url}/.well-known/oauth-authorization-server"
-            mock_get.assert_called_once_with(expected_url)
-
-
 class TestInvokeWithoutAuth:
     """Test invoke method without authentication (should work with valid token)."""
 

--- a/packages/oauth/src/keycardai/oauth/client.py
+++ b/packages/oauth/src/keycardai/oauth/client.py
@@ -676,6 +676,7 @@ class AsyncClient:
         redirect_uri: str,
         code_verifier: str,
         client_id: str | None = None,
+        resource: str | None = None,
         timeout: float | None = None,
     ) -> TokenResponse:
         """Exchange an authorization code for tokens.
@@ -690,6 +691,8 @@ class AsyncClient:
             client_id: Client ID for the form body. Required for public
                 clients. Optional for confidential clients where identity
                 is provided via the auth strategy.
+            resource: Optional RFC 8707 resource indicator. Scopes the
+                issued token to a specific resource.
             timeout: Optional request timeout override.
 
         Returns:
@@ -716,6 +719,7 @@ class AsyncClient:
             code_verifier=code_verifier,
             client_id=client_id,
             context=ctx,
+            resource=resource,
         )
 
     async def impersonate(
@@ -1247,6 +1251,7 @@ class Client:
         redirect_uri: str,
         code_verifier: str,
         client_id: str | None = None,
+        resource: str | None = None,
         timeout: float | None = None,
     ) -> TokenResponse:
         """Exchange an authorization code for tokens.
@@ -1261,6 +1266,8 @@ class Client:
             client_id: Client ID for the form body. Required for public
                 clients. Optional for confidential clients where identity
                 is provided via the auth strategy.
+            resource: Optional RFC 8707 resource indicator. Scopes the
+                issued token to a specific resource.
             timeout: Optional request timeout override.
 
         Returns:
@@ -1287,6 +1294,7 @@ class Client:
             code_verifier=code_verifier,
             client_id=client_id,
             context=ctx,
+            resource=resource,
         )
 
     def impersonate(

--- a/packages/oauth/src/keycardai/oauth/operations/_authorize.py
+++ b/packages/oauth/src/keycardai/oauth/operations/_authorize.py
@@ -71,6 +71,7 @@ def build_authorization_code_http_request(
     code_verifier: str,
     client_id: str | None,
     context: HTTPContext,
+    resource: str | None = None,
 ) -> HttpRequest:
     """Build the HTTP request for an authorization code exchange.
 
@@ -81,6 +82,8 @@ def build_authorization_code_http_request(
         client_id: Client ID to include in the form body (required for
             public clients, optional for confidential clients).
         context: HTTP context with endpoint, transport, and auth.
+        resource: Optional RFC 8707 resource indicator. Scopes the issued
+            token to a specific resource.
 
     Returns:
         HttpRequest ready to send.
@@ -93,6 +96,8 @@ def build_authorization_code_http_request(
     }
     if client_id is not None:
         payload["client_id"] = client_id
+    if resource is not None:
+        payload["resource"] = resource
 
     headers = {
         "Accept": "application/json",
@@ -193,6 +198,7 @@ def exchange_authorization_code(
     code_verifier: str,
     client_id: str | None = None,
     context: HTTPContext,
+    resource: str | None = None,
 ) -> TokenResponse:
     """Exchange an authorization code for tokens (sync).
 
@@ -202,6 +208,7 @@ def exchange_authorization_code(
         code_verifier: The PKCE code verifier.
         client_id: Client ID for the form body. Required for public clients.
         context: HTTP context with endpoint, transport, and auth.
+        resource: Optional RFC 8707 resource indicator.
 
     Returns:
         TokenResponse with tokens.
@@ -216,6 +223,7 @@ def exchange_authorization_code(
         code_verifier=code_verifier,
         client_id=client_id,
         context=context,
+        resource=resource,
     )
     http_res = context.transport.request_raw(http_req, timeout=context.timeout)
     return parse_authorization_code_http_response(http_res)
@@ -228,6 +236,7 @@ async def exchange_authorization_code_async(
     code_verifier: str,
     client_id: str | None = None,
     context: HTTPContext,
+    resource: str | None = None,
 ) -> TokenResponse:
     """Exchange an authorization code for tokens (async).
 
@@ -237,6 +246,7 @@ async def exchange_authorization_code_async(
         code_verifier: The PKCE code verifier.
         client_id: Client ID for the form body. Required for public clients.
         context: HTTP context with endpoint, transport, and auth.
+        resource: Optional RFC 8707 resource indicator.
 
     Returns:
         TokenResponse with tokens.
@@ -251,6 +261,7 @@ async def exchange_authorization_code_async(
         code_verifier=code_verifier,
         client_id=client_id,
         context=context,
+        resource=resource,
     )
     http_res = await context.transport.request_raw(http_req, timeout=context.timeout)
     return parse_authorization_code_http_response(http_res)

--- a/packages/oauth/src/keycardai/oauth/pkce/__init__.py
+++ b/packages/oauth/src/keycardai/oauth/pkce/__init__.py
@@ -1,0 +1,23 @@
+"""High-level PKCE flow for browser-based OAuth 2.0 user authentication.
+
+Builds on the lower-level PKCE primitives in :mod:`keycardai.oauth.utils.pkce`
+to drive the full authorization code with PKCE flow: discovery from a
+``WWW-Authenticate`` challenge (RFC 9728), local callback server, browser
+authorization, and token exchange.
+
+Example::
+
+    from keycardai.oauth.pkce import PKCEClient
+
+    async with PKCEClient(client_id="my-app") as pkce:
+        token = await pkce.authenticate(
+            resource_url="https://api.example.com",
+            www_authenticate_header=resp.headers["WWW-Authenticate"],
+        )
+        print(token.access_token)
+"""
+
+from .callback import OAuthCallbackServer
+from .client import PKCEClient
+
+__all__ = ["OAuthCallbackServer", "PKCEClient"]

--- a/packages/oauth/src/keycardai/oauth/pkce/__init__.py
+++ b/packages/oauth/src/keycardai/oauth/pkce/__init__.py
@@ -1,23 +1,24 @@
 """High-level PKCE flow for browser-based OAuth 2.0 user authentication.
 
 Builds on the lower-level PKCE primitives in :mod:`keycardai.oauth.utils.pkce`
-to drive the full authorization code with PKCE flow: discovery from a
-``WWW-Authenticate`` challenge (RFC 9728), local callback server, browser
-authorization, and token exchange.
+and reuses :class:`keycardai.oauth.AsyncClient` for the OAuth-server-facing
+operations (server metadata discovery, code exchange). This package owns the
+user-flow orchestration on top: discovery from a ``WWW-Authenticate``
+challenge (RFC 9728), local callback server (RFC 8252), and browser launch.
 
 Example::
 
-    from keycardai.oauth.pkce import PKCEClient
+    from keycardai.oauth.pkce import authenticate
 
-    async with PKCEClient(client_id="my-app") as pkce:
-        token = await pkce.authenticate(
-            resource_url="https://api.example.com",
-            www_authenticate_header=resp.headers["WWW-Authenticate"],
-        )
-        print(token.access_token)
+    token = await authenticate(
+        client_id="my-app",
+        resource_url="https://api.example.com",
+        www_authenticate_header=resp.headers["WWW-Authenticate"],
+    )
+    print(token.access_token)
 """
 
 from .callback import OAuthCallbackServer
-from .client import PKCEClient
+from .client import authenticate
 
-__all__ = ["OAuthCallbackServer", "PKCEClient"]
+__all__ = ["OAuthCallbackServer", "authenticate"]

--- a/packages/oauth/src/keycardai/oauth/pkce/callback.py
+++ b/packages/oauth/src/keycardai/oauth/pkce/callback.py
@@ -1,0 +1,105 @@
+"""Local HTTP server for receiving OAuth authorization code callbacks."""
+
+import asyncio
+import logging
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from threading import Thread
+from urllib.parse import parse_qs, urlparse
+
+logger = logging.getLogger(__name__)
+
+
+class OAuthCallbackServer:
+    """Local HTTP server that captures the authorization code from a redirect.
+
+    Starts an :class:`http.server.HTTPServer` on ``localhost`` to receive the
+    authorization code from the OAuth provider after the user authorizes in
+    their browser. Exposes the captured ``code`` (or ``error``) via
+    :meth:`wait_for_code`.
+
+    Intended for desktop / CLI public clients running the PKCE flow against a
+    loopback redirect URI (RFC 8252).
+    """
+
+    def __init__(self, port: int = 8765):
+        self.port = port
+        self.code: str | None = None
+        self.error: str | None = None
+        self.server: HTTPServer | None = None
+        self.server_thread: Thread | None = None
+
+    def _create_handler(self):
+        server_instance = self
+
+        class CallbackHandler(BaseHTTPRequestHandler):
+            def log_message(self, format, *args):
+                pass
+
+            def do_GET(self):
+                parsed = urlparse(self.path)
+                params = parse_qs(parsed.query)
+
+                if "code" in params:
+                    server_instance.code = params["code"][0]
+                    message = "Authentication successful. You can close this window."
+                    self.send_response(200)
+                elif "error" in params:
+                    server_instance.error = params["error"][0]
+                    error_desc = params.get("error_description", ["Unknown error"])[0]
+                    message = f"Authentication failed: {error_desc}"
+                    self.send_response(400)
+                else:
+                    message = "Invalid callback: missing code or error."
+                    self.send_response(400)
+
+                self.send_header("Content-type", "text/html")
+                self.end_headers()
+                html = f"""
+                <html>
+                <head><title>OAuth Callback</title></head>
+                <body>
+                    <h1>{message}</h1>
+                    <p>This window will close automatically...</p>
+                    <script>setTimeout(() => window.close(), 2000);</script>
+                </body>
+                </html>
+                """
+                self.wfile.write(html.encode())
+
+        return CallbackHandler
+
+    async def start(self) -> None:
+        """Start the callback server in a background thread."""
+        self.server = HTTPServer(("localhost", self.port), self._create_handler())
+        self.server_thread = Thread(target=self.server.serve_forever, daemon=True)
+        self.server_thread.start()
+        logger.debug("OAuth callback server started on port %d", self.port)
+
+    async def wait_for_code(self, timeout: int = 300) -> str:
+        """Wait for the authorization code from the redirect.
+
+        Args:
+            timeout: Maximum time to wait, in seconds.
+
+        Returns:
+            The authorization code.
+
+        Raises:
+            TimeoutError: If no code is received within the timeout.
+            RuntimeError: If the redirect carried an OAuth error parameter.
+        """
+        elapsed = 0.0
+        while elapsed < timeout:
+            if self.code:
+                return self.code
+            if self.error:
+                raise RuntimeError(f"OAuth error: {self.error}")
+            await asyncio.sleep(0.5)
+            elapsed += 0.5
+        raise TimeoutError(f"OAuth callback timeout after {timeout}s")
+
+    def stop(self) -> None:
+        """Shut the callback server down."""
+        if self.server:
+            self.server.shutdown()
+            logger.debug("OAuth callback server stopped")

--- a/packages/oauth/src/keycardai/oauth/pkce/client.py
+++ b/packages/oauth/src/keycardai/oauth/pkce/client.py
@@ -1,18 +1,26 @@
-"""High-level PKCE flow client for browser-based OAuth 2.0 user authentication.
+"""High-level PKCE flow for browser-based OAuth 2.0 user authentication.
 
-Drives the full authorization code with PKCE flow:
+The :func:`authenticate` function drives the full authorization code with
+PKCE flow:
 
-1. Parse the ``WWW-Authenticate`` challenge from the protected resource (RFC 9728)
-2. Fetch protected resource metadata, then authorization server metadata (RFC 8414)
+1. Parse the ``WWW-Authenticate`` challenge from the protected resource
+   (RFC 9728)
+2. Fetch protected resource metadata, then drive
+   :class:`keycardai.oauth.AsyncClient` against the discovered authorization
+   server for metadata discovery (RFC 8414) and code exchange (RFC 6749 +
+   RFC 7636)
 3. Generate a PKCE verifier/challenge pair (RFC 7636) and a CSRF state value
-4. Start a local callback server, open the user's browser at the authorize endpoint
+4. Start a local callback server, open the user's browser at the authorize
+   endpoint
 5. Receive the authorization code from the redirect
-6. Exchange the code at the token endpoint and return a :class:`TokenResponse`
+6. Exchange the code at the token endpoint and return a
+   :class:`~keycardai.oauth.types.models.TokenResponse`
 
-The actual PKCE primitives (``PKCEGenerator``, ``build_authorize_url``,
-``exchange_authorization_code_async``) live elsewhere in
-:mod:`keycardai.oauth`; this module is the thin orchestration layer that
-wires them together with browser + callback machinery.
+The OAuth-server-facing operations (server metadata discovery, token
+exchange) go through :class:`AsyncClient` so there is one client surface in
+``keycardai.oauth`` that talks to OAuth servers. This module is the
+user-flow orchestration on top: it parses the RFC 9728 challenge, opens the
+browser, and runs the loopback callback server (RFC 8252).
 """
 
 import logging
@@ -20,208 +28,150 @@ import re
 import secrets
 import webbrowser
 from typing import Any
-from urllib.parse import urlencode
 
 import httpx
 
+from ..client import AsyncClient
+from ..http.auth import BasicAuth, NoneAuth
+from ..operations._authorize import build_authorize_url
+from ..types.models import ClientConfig, TokenResponse
 from ..utils.pkce import PKCEGenerator
 from .callback import OAuthCallbackServer
 
 logger = logging.getLogger(__name__)
 
 
-class PKCEClient:
-    """OAuth 2.0 user-login client using authorization code with PKCE.
+async def authenticate(
+    *,
+    client_id: str,
+    resource_url: str,
+    www_authenticate_header: str,
+    client_secret: str | None = None,
+    redirect_uri: str = "http://localhost:8765/callback",
+    callback_port: int = 8765,
+    scopes: list[str] | None = None,
+    callback_timeout: int = 300,
+    http_client: httpx.AsyncClient | None = None,
+) -> TokenResponse:
+    """Run the OAuth 2.0 authorization-code-with-PKCE flow against the issuer
+    advertised by ``www_authenticate_header``.
 
-    Targets desktop / CLI public clients running against a loopback redirect URI
-    (RFC 8252). Intended to be used as an async context manager.
-
-    Example::
-
-        async with PKCEClient(client_id="my-app") as pkce:
-            token = await pkce.authenticate(
-                resource_url="https://api.example.com",
-                www_authenticate_header=resp.headers["WWW-Authenticate"],
-            )
+    Targets desktop / CLI public clients running against a loopback redirect
+    URI (RFC 8252). Confidential clients pass ``client_secret`` and get HTTP
+    Basic auth on the token endpoint.
 
     Args:
         client_id: OAuth client ID.
-        client_secret: Optional client secret. Public clients (the PKCE use
-            case) usually omit this.
+        resource_url: The protected resource the caller is targeting. Passed
+            through as the RFC 8707 ``resource`` parameter on both the
+            authorize and token requests.
+        www_authenticate_header: The ``WWW-Authenticate`` value from the
+            resource's 401 response. Must contain a ``resource_metadata``
+            URL per RFC 9728.
+        client_secret: Optional client secret for confidential clients.
+            Public clients (the typical PKCE use case) omit this.
         redirect_uri: Loopback redirect URI registered with the authorization
             server.
         callback_port: Port for the local callback server.
         scopes: Optional list of OAuth scopes to request.
-        timeout: HTTP timeout for metadata and token requests when this
-            client owns its ``httpx.AsyncClient``. Ignored if ``http_client``
-            is supplied.
-        http_client: Optional ``httpx.AsyncClient`` to share with another
-            component. When provided, ``close()`` does not close it; the
-            owner of the injected client is responsible for its lifecycle.
+        callback_timeout: How long to wait for the user to complete
+            authorization, in seconds.
+        http_client: Optional ``httpx.AsyncClient`` to use for fetching the
+            protected resource metadata document. When not supplied, a
+            short-lived client is created internally. The OAuth-server
+            calls (server metadata discovery, token exchange) always go
+            through a fresh :class:`AsyncClient`.
+
+    Returns:
+        ``TokenResponse`` from the token endpoint.
+
+    Raises:
+        ValueError: If discovery fails (no ``resource_metadata`` in the
+            challenge, no ``authorization_servers`` in the metadata, or the
+            authorization server is missing required endpoints).
+        httpx.HTTPStatusError: If the resource metadata fetch fails.
+        keycardai.oauth.OAuthHttpError: If the OAuth server's metadata or
+            token endpoint returns an HTTP error.
+        keycardai.oauth.OAuthProtocolError: If the token endpoint response
+            contains an OAuth error.
+        TimeoutError: If the user does not complete authorization within
+            ``callback_timeout``.
+        RuntimeError: If the authorization redirect carried an OAuth
+            ``error`` parameter.
     """
+    logger.info("PKCE flow starting for resource %s", resource_url)
 
-    def __init__(
-        self,
-        client_id: str,
-        *,
-        client_secret: str | None = None,
-        redirect_uri: str = "http://localhost:8765/callback",
-        callback_port: int = 8765,
-        scopes: list[str] | None = None,
-        timeout: float = 30.0,
-        http_client: httpx.AsyncClient | None = None,
-    ):
-        self.client_id = client_id
-        self.client_secret = client_secret
-        self.redirect_uri = redirect_uri
-        self.callback_port = callback_port
-        self.scopes = scopes or []
-        if http_client is not None:
-            self._http = http_client
-            self._owns_http = False
-        else:
-            self._http = httpx.AsyncClient(timeout=timeout)
-            self._owns_http = True
+    metadata_url = _extract_resource_metadata_url(www_authenticate_header)
+    if not metadata_url:
+        raise ValueError("No resource_metadata URL in WWW-Authenticate header")
 
-    async def authenticate(
-        self,
-        resource_url: str,
-        www_authenticate_header: str,
-        callback_timeout: int = 300,
-    ) -> dict[str, Any]:
-        """Run the PKCE flow against the issuer advertised by the resource.
+    resource_metadata = await _fetch_resource_metadata(metadata_url, http_client)
+    auth_servers = resource_metadata.get("authorization_servers") or []
+    if not auth_servers:
+        raise ValueError("No authorization_servers in resource metadata")
 
-        Args:
-            resource_url: The protected resource the caller is targeting.
-                Passed through as the RFC 8707 ``resource`` parameter.
-            www_authenticate_header: The ``WWW-Authenticate`` value from the
-                resource's 401 response. Must contain a ``resource_metadata``
-                URL per RFC 9728.
-            callback_timeout: How long to wait for the user to complete
-                authorization, in seconds.
+    auth_server_url = auth_servers[0].rstrip("/")
 
-        Returns:
-            The raw token endpoint response as a dict (always includes
-            ``access_token``; usually includes ``token_type``, ``expires_in``,
-            and may include ``refresh_token``, ``id_token``, ``scope``).
+    auth_strategy = (
+        BasicAuth(client_id, client_secret) if client_secret else NoneAuth()
+    )
+    config = ClientConfig(enable_metadata_discovery=True, auto_register_client=False)
 
-        Raises:
-            ValueError: If discovery fails (no ``resource_metadata`` in the
-                challenge, no ``authorization_servers`` in the metadata, or
-                missing endpoints in the auth server metadata).
-            httpx.HTTPStatusError: If a metadata fetch or token exchange
-                request fails.
-            TimeoutError: If the user does not complete authorization within
-                ``callback_timeout``.
-            RuntimeError: If the authorization redirect carried an OAuth
-                ``error`` parameter.
-        """
-        logger.info("PKCE flow starting for resource %s", resource_url)
-
-        metadata_url = _extract_resource_metadata_url(www_authenticate_header)
-        if not metadata_url:
+    async with AsyncClient(
+        base_url=auth_server_url, auth=auth_strategy, config=config
+    ) as oauth_client:
+        endpoints = await oauth_client.get_endpoints()
+        if not endpoints.authorize or not endpoints.token:
             raise ValueError(
-                "No resource_metadata URL in WWW-Authenticate header"
-            )
-
-        resource_metadata = await self._fetch_json(metadata_url)
-        auth_servers = resource_metadata.get("authorization_servers") or []
-        if not auth_servers:
-            raise ValueError("No authorization_servers in resource metadata")
-
-        auth_server_url = auth_servers[0].rstrip("/")
-        auth_server_metadata = await self._fetch_json(
-            f"{auth_server_url}/.well-known/oauth-authorization-server"
-        )
-
-        authorization_endpoint = auth_server_metadata.get("authorization_endpoint")
-        token_endpoint = auth_server_metadata.get("token_endpoint")
-        if not authorization_endpoint or not token_endpoint:
-            raise ValueError(
-                "Missing authorization_endpoint or token_endpoint in metadata"
+                "Authorization server metadata is missing authorization_endpoint "
+                "or token_endpoint"
             )
 
         pkce = PKCEGenerator().generate_pkce_pair()
         state = secrets.token_urlsafe(32)
+        authorization_url = build_authorize_url(
+            endpoints.authorize,
+            client_id=client_id,
+            redirect_uri=redirect_uri,
+            pkce=pkce,
+            resources=[resource_url],
+            scope=" ".join(scopes) if scopes else None,
+            state=state,
+        )
 
-        callback_server = OAuthCallbackServer(self.callback_port)
+        callback_server = OAuthCallbackServer(callback_port)
         await callback_server.start()
         try:
-            authorization_url = self._build_authorization_url(
-                authorization_endpoint, resource_url, pkce.code_challenge, state
-            )
             logger.info("Opening browser for user authorization")
             webbrowser.open(authorization_url)
-
             code = await callback_server.wait_for_code(timeout=callback_timeout)
             logger.info("Authorization code received; exchanging for token")
-
-            return await self._exchange_code(
-                token_endpoint, code, pkce.code_verifier, resource_url
-            )
         finally:
             callback_server.stop()
 
-    async def close(self) -> None:
-        if self._owns_http:
-            await self._http.aclose()
+        return await oauth_client.exchange_authorization_code(
+            code=code,
+            redirect_uri=redirect_uri,
+            code_verifier=pkce.code_verifier,
+            client_id=client_id,
+            resource=resource_url,
+        )
 
-    async def __aenter__(self) -> "PKCEClient":
-        return self
 
-    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
-        await self.close()
+async def _fetch_resource_metadata(
+    metadata_url: str, http_client: httpx.AsyncClient | None
+) -> dict[str, Any]:
+    """Fetch the RFC 9728 protected resource metadata document.
 
-    async def _fetch_json(self, url: str) -> dict[str, Any]:
-        response = await self._http.get(url)
+    This step is paired with the protected resource (not the OAuth server),
+    so it lives outside :class:`AsyncClient`.
+    """
+    if http_client is not None:
+        response = await http_client.get(metadata_url)
         response.raise_for_status()
         return response.json()
-
-    def _build_authorization_url(
-        self,
-        authorization_endpoint: str,
-        resource_url: str,
-        code_challenge: str,
-        state: str,
-    ) -> str:
-        params: dict[str, str] = {
-            "response_type": "code",
-            "client_id": self.client_id,
-            "redirect_uri": self.redirect_uri,
-            "state": state,
-            "code_challenge": code_challenge,
-            "code_challenge_method": "S256",
-            "resource": resource_url,
-        }
-        if self.scopes:
-            params["scope"] = " ".join(self.scopes)
-        return f"{authorization_endpoint}?{urlencode(params)}"
-
-    async def _exchange_code(
-        self,
-        token_endpoint: str,
-        code: str,
-        code_verifier: str,
-        resource_url: str,
-    ) -> dict[str, Any]:
-        token_params: dict[str, str] = {
-            "grant_type": "authorization_code",
-            "code": code,
-            "redirect_uri": self.redirect_uri,
-            "client_id": self.client_id,
-            "code_verifier": code_verifier,
-            "resource": resource_url,
-        }
-        auth_tuple = None
-        if self.client_secret:
-            auth_tuple = (self.client_id, self.client_secret)
-
-        response = await self._http.post(
-            token_endpoint,
-            data=token_params,
-            auth=auth_tuple,
-            headers={"Content-Type": "application/x-www-form-urlencoded"},
-        )
+    async with httpx.AsyncClient(timeout=30.0) as client:
+        response = await client.get(metadata_url)
         response.raise_for_status()
         return response.json()
 

--- a/packages/oauth/src/keycardai/oauth/pkce/client.py
+++ b/packages/oauth/src/keycardai/oauth/pkce/client.py
@@ -1,0 +1,223 @@
+"""High-level PKCE flow client for browser-based OAuth 2.0 user authentication.
+
+Drives the full authorization code with PKCE flow:
+
+1. Parse the ``WWW-Authenticate`` challenge from the protected resource (RFC 9728)
+2. Fetch protected resource metadata, then authorization server metadata (RFC 8414)
+3. Generate a PKCE verifier/challenge pair (RFC 7636) and a CSRF state value
+4. Start a local callback server, open the user's browser at the authorize endpoint
+5. Receive the authorization code from the redirect
+6. Exchange the code at the token endpoint and return a :class:`TokenResponse`
+
+The actual PKCE primitives (``PKCEGenerator``, ``build_authorize_url``,
+``exchange_authorization_code_async``) live elsewhere in
+:mod:`keycardai.oauth`; this module is the thin orchestration layer that
+wires them together with browser + callback machinery.
+"""
+
+import logging
+import re
+import secrets
+import webbrowser
+from typing import Any
+from urllib.parse import urlencode
+
+import httpx
+
+from ..utils.pkce import PKCEGenerator
+from .callback import OAuthCallbackServer
+
+logger = logging.getLogger(__name__)
+
+
+class PKCEClient:
+    """OAuth 2.0 user-login client using authorization code with PKCE.
+
+    Targets desktop / CLI public clients running against a loopback redirect URI
+    (RFC 8252). Intended to be used as an async context manager.
+
+    Example::
+
+        async with PKCEClient(client_id="my-app") as pkce:
+            token = await pkce.authenticate(
+                resource_url="https://api.example.com",
+                www_authenticate_header=resp.headers["WWW-Authenticate"],
+            )
+
+    Args:
+        client_id: OAuth client ID.
+        client_secret: Optional client secret. Public clients (the PKCE use
+            case) usually omit this.
+        redirect_uri: Loopback redirect URI registered with the authorization
+            server.
+        callback_port: Port for the local callback server.
+        scopes: Optional list of OAuth scopes to request.
+        timeout: HTTP timeout for metadata and token requests.
+    """
+
+    def __init__(
+        self,
+        client_id: str,
+        *,
+        client_secret: str | None = None,
+        redirect_uri: str = "http://localhost:8765/callback",
+        callback_port: int = 8765,
+        scopes: list[str] | None = None,
+        timeout: float = 30.0,
+    ):
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.redirect_uri = redirect_uri
+        self.callback_port = callback_port
+        self.scopes = scopes or []
+        self._http = httpx.AsyncClient(timeout=timeout)
+
+    async def authenticate(
+        self,
+        resource_url: str,
+        www_authenticate_header: str,
+        callback_timeout: int = 300,
+    ) -> dict[str, Any]:
+        """Run the PKCE flow against the issuer advertised by the resource.
+
+        Args:
+            resource_url: The protected resource the caller is targeting.
+                Passed through as the RFC 8707 ``resource`` parameter.
+            www_authenticate_header: The ``WWW-Authenticate`` value from the
+                resource's 401 response. Must contain a ``resource_metadata``
+                URL per RFC 9728.
+            callback_timeout: How long to wait for the user to complete
+                authorization, in seconds.
+
+        Returns:
+            The raw token endpoint response as a dict (always includes
+            ``access_token``; usually includes ``token_type``, ``expires_in``,
+            and may include ``refresh_token``, ``id_token``, ``scope``).
+
+        Raises:
+            ValueError: If discovery fails (no ``resource_metadata`` in the
+                challenge, no ``authorization_servers`` in the metadata, or
+                missing endpoints in the auth server metadata).
+            httpx.HTTPStatusError: If a metadata fetch or token exchange
+                request fails.
+            TimeoutError: If the user does not complete authorization within
+                ``callback_timeout``.
+            RuntimeError: If the authorization redirect carried an OAuth
+                ``error`` parameter.
+        """
+        logger.info("PKCE flow starting for resource %s", resource_url)
+
+        metadata_url = _extract_resource_metadata_url(www_authenticate_header)
+        if not metadata_url:
+            raise ValueError(
+                "No resource_metadata URL in WWW-Authenticate header"
+            )
+
+        resource_metadata = await self._fetch_json(metadata_url)
+        auth_servers = resource_metadata.get("authorization_servers") or []
+        if not auth_servers:
+            raise ValueError("No authorization_servers in resource metadata")
+
+        auth_server_url = auth_servers[0].rstrip("/") + "/"
+        auth_server_metadata = await self._fetch_json(
+            f"{auth_server_url.rstrip('/')}/.well-known/oauth-authorization-server"
+        )
+
+        authorization_endpoint = auth_server_metadata.get("authorization_endpoint")
+        token_endpoint = auth_server_metadata.get("token_endpoint")
+        if not authorization_endpoint or not token_endpoint:
+            raise ValueError(
+                "Missing authorization_endpoint or token_endpoint in metadata"
+            )
+
+        pkce = PKCEGenerator().generate_pkce_pair()
+        state = secrets.token_urlsafe(32)
+
+        callback_server = OAuthCallbackServer(self.callback_port)
+        await callback_server.start()
+        try:
+            authorization_url = self._build_authorization_url(
+                authorization_endpoint, resource_url, pkce.code_challenge, state
+            )
+            logger.info("Opening browser for user authorization")
+            webbrowser.open(authorization_url)
+
+            code = await callback_server.wait_for_code(timeout=callback_timeout)
+            logger.info("Authorization code received; exchanging for token")
+
+            return await self._exchange_code(
+                token_endpoint, code, pkce.code_verifier, resource_url
+            )
+        finally:
+            callback_server.stop()
+
+    async def close(self) -> None:
+        await self._http.aclose()
+
+    async def __aenter__(self) -> "PKCEClient":
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+        await self.close()
+
+    async def _fetch_json(self, url: str) -> dict[str, Any]:
+        response = await self._http.get(url)
+        response.raise_for_status()
+        return response.json()
+
+    def _build_authorization_url(
+        self,
+        authorization_endpoint: str,
+        resource_url: str,
+        code_challenge: str,
+        state: str,
+    ) -> str:
+        params: dict[str, str] = {
+            "response_type": "code",
+            "client_id": self.client_id,
+            "redirect_uri": self.redirect_uri,
+            "state": state,
+            "code_challenge": code_challenge,
+            "code_challenge_method": "S256",
+            "resource": resource_url,
+        }
+        if self.scopes:
+            params["scope"] = " ".join(self.scopes)
+        return f"{authorization_endpoint}?{urlencode(params)}"
+
+    async def _exchange_code(
+        self,
+        token_endpoint: str,
+        code: str,
+        code_verifier: str,
+        resource_url: str,
+    ) -> dict[str, Any]:
+        token_params: dict[str, str] = {
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": self.redirect_uri,
+            "client_id": self.client_id,
+            "code_verifier": code_verifier,
+            "resource": resource_url,
+        }
+        auth_tuple = None
+        if self.client_secret:
+            auth_tuple = (self.client_id, self.client_secret)
+
+        response = await self._http.post(
+            token_endpoint,
+            data=token_params,
+            auth=auth_tuple,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+        response.raise_for_status()
+        return response.json()
+
+
+def _extract_resource_metadata_url(www_authenticate: str) -> str | None:
+    """Extract the ``resource_metadata`` URL from a ``WWW-Authenticate`` header.
+
+    See RFC 9728 §5.3 for the parameter definition.
+    """
+    match = re.search(r'resource_metadata="([^"]+)"', www_authenticate)
+    return match.group(1) if match else None

--- a/packages/oauth/src/keycardai/oauth/pkce/client.py
+++ b/packages/oauth/src/keycardai/oauth/pkce/client.py
@@ -52,7 +52,12 @@ class PKCEClient:
             server.
         callback_port: Port for the local callback server.
         scopes: Optional list of OAuth scopes to request.
-        timeout: HTTP timeout for metadata and token requests.
+        timeout: HTTP timeout for metadata and token requests when this
+            client owns its ``httpx.AsyncClient``. Ignored if ``http_client``
+            is supplied.
+        http_client: Optional ``httpx.AsyncClient`` to share with another
+            component. When provided, ``close()`` does not close it; the
+            owner of the injected client is responsible for its lifecycle.
     """
 
     def __init__(
@@ -64,13 +69,19 @@ class PKCEClient:
         callback_port: int = 8765,
         scopes: list[str] | None = None,
         timeout: float = 30.0,
+        http_client: httpx.AsyncClient | None = None,
     ):
         self.client_id = client_id
         self.client_secret = client_secret
         self.redirect_uri = redirect_uri
         self.callback_port = callback_port
         self.scopes = scopes or []
-        self._http = httpx.AsyncClient(timeout=timeout)
+        if http_client is not None:
+            self._http = http_client
+            self._owns_http = False
+        else:
+            self._http = httpx.AsyncClient(timeout=timeout)
+            self._owns_http = True
 
     async def authenticate(
         self,
@@ -118,9 +129,9 @@ class PKCEClient:
         if not auth_servers:
             raise ValueError("No authorization_servers in resource metadata")
 
-        auth_server_url = auth_servers[0].rstrip("/") + "/"
+        auth_server_url = auth_servers[0].rstrip("/")
         auth_server_metadata = await self._fetch_json(
-            f"{auth_server_url.rstrip('/')}/.well-known/oauth-authorization-server"
+            f"{auth_server_url}/.well-known/oauth-authorization-server"
         )
 
         authorization_endpoint = auth_server_metadata.get("authorization_endpoint")
@@ -152,7 +163,8 @@ class PKCEClient:
             callback_server.stop()
 
     async def close(self) -> None:
-        await self._http.aclose()
+        if self._owns_http:
+            await self._http.aclose()
 
     async def __aenter__(self) -> "PKCEClient":
         return self

--- a/packages/oauth/tests/keycardai/oauth/pkce/test_client.py
+++ b/packages/oauth/tests/keycardai/oauth/pkce/test_client.py
@@ -1,7 +1,7 @@
-"""Tests for keycardai.oauth.pkce.PKCEClient.
+"""Tests for keycardai.oauth.pkce.authenticate.
 
-Mocks httpx and the local callback server to drive the full authentication
-flow without opening a browser.
+Mocks the resource metadata fetch and the internal AsyncClient to drive the
+full authentication flow without opening a browser or making network calls.
 """
 
 from unittest.mock import AsyncMock, MagicMock
@@ -9,8 +9,10 @@ from unittest.mock import AsyncMock, MagicMock
 import httpx
 import pytest
 
-from keycardai.oauth.pkce import OAuthCallbackServer, PKCEClient
+from keycardai.oauth.http.auth import BasicAuth, NoneAuth
+from keycardai.oauth.pkce import OAuthCallbackServer, authenticate
 from keycardai.oauth.pkce.client import _extract_resource_metadata_url
+from keycardai.oauth.types.models import TokenResponse
 
 WWW_AUTHENTICATE = (
     'Bearer error="invalid_token", '
@@ -30,150 +32,137 @@ def test_extract_resource_metadata_url_returns_none_when_missing():
 
 @pytest.mark.asyncio
 async def test_authenticate_raises_when_header_has_no_metadata_url():
-    async with PKCEClient(client_id="cid") as pkce:
-        with pytest.raises(ValueError, match="No resource_metadata"):
-            await pkce.authenticate(
-                resource_url="https://api.example.com",
-                www_authenticate_header='Bearer error="invalid_token"',
-            )
+    with pytest.raises(ValueError, match="No resource_metadata"):
+        await authenticate(
+            client_id="cid",
+            resource_url="https://api.example.com",
+            www_authenticate_header='Bearer error="invalid_token"',
+        )
 
 
 @pytest.mark.asyncio
 async def test_authenticate_raises_when_metadata_has_no_auth_servers():
-    async with PKCEClient(client_id="cid") as pkce:
-        pkce._http = MagicMock(
-            get=AsyncMock(return_value=_mock_json_response({"authorization_servers": []})),
-            aclose=AsyncMock(),
+    http_mock = _http_client_mock([{"authorization_servers": []}])
+    with pytest.raises(ValueError, match="No authorization_servers"):
+        await authenticate(
+            client_id="cid",
+            resource_url="https://api.example.com",
+            www_authenticate_header=WWW_AUTHENTICATE,
+            http_client=http_mock,
         )
-        with pytest.raises(ValueError, match="No authorization_servers"):
-            await pkce.authenticate(
-                resource_url="https://api.example.com",
-                www_authenticate_header=WWW_AUTHENTICATE,
-            )
 
 
 @pytest.mark.asyncio
-async def test_authenticate_raises_when_auth_server_missing_endpoints():
-    async with PKCEClient(client_id="cid") as pkce:
-        pkce._http = _http_mock(
-            [
-                {"authorization_servers": ["https://auth.example.com"]},
-                {"issuer": "https://auth.example.com"},  # no endpoints
-            ]
+async def test_authenticate_raises_when_auth_server_missing_endpoints(monkeypatch):
+    http_mock = _http_client_mock(
+        [{"authorization_servers": ["https://auth.example.com"]}]
+    )
+    fake_async_client = _async_client_factory(
+        endpoints=MagicMock(authorize=None, token=None)
+    )
+    monkeypatch.setattr(
+        "keycardai.oauth.pkce.client.AsyncClient", fake_async_client
+    )
+
+    with pytest.raises(
+        ValueError, match="missing authorization_endpoint or token_endpoint"
+    ):
+        await authenticate(
+            client_id="cid",
+            resource_url="https://api.example.com",
+            www_authenticate_header=WWW_AUTHENTICATE,
+            http_client=http_mock,
         )
-        with pytest.raises(ValueError, match="Missing authorization_endpoint"):
-            await pkce.authenticate(
-                resource_url="https://api.example.com",
-                www_authenticate_header=WWW_AUTHENTICATE,
-            )
 
 
 @pytest.mark.asyncio
 async def test_authenticate_completes_full_flow(monkeypatch):
-    """Drives the happy path with mocked metadata, callback, and token endpoint."""
-    callback_mock = MagicMock(spec=OAuthCallbackServer)
-    callback_mock.start = AsyncMock()
-    callback_mock.wait_for_code = AsyncMock(return_value="auth-code-123")
-    callback_mock.stop = MagicMock()
+    """Drives the happy path through resource metadata + AsyncClient + callback."""
+    callback_mock = _patch_callback_and_browser(monkeypatch, code="auth-code-123")
+
+    token_response = TokenResponse(
+        access_token="downstream-token",
+        token_type="Bearer",
+        expires_in=3600,
+    )
+    captured = {}
+    fake_async_client = _async_client_factory(
+        endpoints=MagicMock(
+            authorize="https://auth.example.com/authorize",
+            token="https://auth.example.com/token",
+        ),
+        exchange_response=token_response,
+        capture=captured,
+    )
     monkeypatch.setattr(
-        "keycardai.oauth.pkce.client.OAuthCallbackServer",
-        lambda port: callback_mock,
+        "keycardai.oauth.pkce.client.AsyncClient", fake_async_client
     )
-    monkeypatch.setattr("keycardai.oauth.pkce.client.webbrowser.open", lambda url: None)
 
-    token_response_body = {
-        "access_token": "downstream-token",
-        "token_type": "Bearer",
-        "expires_in": 3600,
-    }
-    http_mock = MagicMock()
-    http_mock.get = AsyncMock(
-        side_effect=[
-            _mock_json_response(
-                {"authorization_servers": ["https://auth.example.com"]}
-            ),
-            _mock_json_response(
-                {
-                    "authorization_endpoint": "https://auth.example.com/authorize",
-                    "token_endpoint": "https://auth.example.com/token",
-                }
-            ),
-        ]
+    http_mock = _http_client_mock(
+        [{"authorization_servers": ["https://auth.example.com"]}]
     )
-    http_mock.post = AsyncMock(return_value=_mock_json_response(token_response_body))
-    http_mock.aclose = AsyncMock()
 
-    async with PKCEClient(
-        client_id="my-app", client_secret="secret"
-    ) as pkce:
-        pkce._http = http_mock
-        result = await pkce.authenticate(
-            resource_url="https://api.example.com",
-            www_authenticate_header=WWW_AUTHENTICATE,
-        )
+    result = await authenticate(
+        client_id="my-app",
+        client_secret="secret",
+        resource_url="https://api.example.com",
+        www_authenticate_header=WWW_AUTHENTICATE,
+        http_client=http_mock,
+    )
 
-    assert result == token_response_body
-    # Browser was opened, callback served, token exchanged.
-    callback_mock.start.assert_called_once()
-    callback_mock.wait_for_code.assert_called_once()
+    assert result is token_response
+    callback_mock.start.assert_awaited_once()
+    callback_mock.wait_for_code.assert_awaited_once()
     callback_mock.stop.assert_called_once()
-    # Discovery: resource metadata first, then RFC 8414 authorization server metadata.
-    assert http_mock.get.call_args_list[0].args[0] == (
+    # Resource metadata was fetched from the URL in the WWW-Authenticate header.
+    http_mock.get.assert_awaited_once_with(
         "https://api.example.com/.well-known/oauth-protected-resource"
     )
-    assert http_mock.get.call_args_list[1].args[0] == (
-        "https://auth.example.com/.well-known/oauth-authorization-server"
-    )
-    http_mock.post.assert_called_once()
-    posted = http_mock.post.call_args
-    assert posted.args[0] == "https://auth.example.com/token"
-    assert posted.kwargs["data"]["grant_type"] == "authorization_code"
-    assert posted.kwargs["data"]["code"] == "auth-code-123"
-    assert posted.kwargs["data"]["resource"] == "https://api.example.com"
-    assert posted.kwargs["data"]["client_id"] == "my-app"
-    # Confidential client uses HTTP Basic auth on the token endpoint.
-    assert posted.kwargs["auth"] == ("my-app", "secret")
+    # AsyncClient was constructed against the discovered authorization server
+    # with HTTP Basic auth (confidential client).
+    assert captured["base_url"] == "https://auth.example.com"
+    assert isinstance(captured["auth"], BasicAuth)
+    assert captured["auth"].client_id == "my-app"
+    assert captured["auth"].client_secret == "secret"
+    # Token exchange was called with the right parameters, including the
+    # RFC 8707 resource indicator.
+    assert captured["exchange_kwargs"]["code"] == "auth-code-123"
+    assert captured["exchange_kwargs"]["client_id"] == "my-app"
+    assert captured["exchange_kwargs"]["resource"] == "https://api.example.com"
 
 
 @pytest.mark.asyncio
-async def test_authenticate_omits_basic_auth_for_public_client(monkeypatch):
-    callback_mock = MagicMock(spec=OAuthCallbackServer)
-    callback_mock.start = AsyncMock()
-    callback_mock.wait_for_code = AsyncMock(return_value="code")
-    callback_mock.stop = MagicMock()
+async def test_authenticate_uses_none_auth_for_public_client(monkeypatch):
+    _patch_callback_and_browser(monkeypatch, code="code")
+    captured = {}
+    fake_async_client = _async_client_factory(
+        endpoints=MagicMock(
+            authorize="https://auth.example.com/authorize",
+            token="https://auth.example.com/token",
+        ),
+        exchange_response=TokenResponse(access_token="tok", token_type="Bearer"),
+        capture=captured,
+    )
     monkeypatch.setattr(
-        "keycardai.oauth.pkce.client.OAuthCallbackServer",
-        lambda port: callback_mock,
+        "keycardai.oauth.pkce.client.AsyncClient", fake_async_client
     )
-    monkeypatch.setattr("keycardai.oauth.pkce.client.webbrowser.open", lambda url: None)
-
-    http_mock = MagicMock()
-    http_mock.get = AsyncMock(
-        side_effect=[
-            _mock_json_response(
-                {"authorization_servers": ["https://auth.example.com"]}
-            ),
-            _mock_json_response(
-                {
-                    "authorization_endpoint": "https://auth.example.com/authorize",
-                    "token_endpoint": "https://auth.example.com/token",
-                }
-            ),
-        ]
+    http_mock = _http_client_mock(
+        [{"authorization_servers": ["https://auth.example.com"]}]
     )
-    http_mock.post = AsyncMock(
-        return_value=_mock_json_response({"access_token": "tok"})
+
+    await authenticate(
+        client_id="public-app",
+        resource_url="https://api.example.com",
+        www_authenticate_header=WWW_AUTHENTICATE,
+        http_client=http_mock,
     )
-    http_mock.aclose = AsyncMock()
 
-    async with PKCEClient(client_id="public-app") as pkce:
-        pkce._http = http_mock
-        await pkce.authenticate(
-            resource_url="https://api.example.com",
-            www_authenticate_header=WWW_AUTHENTICATE,
-        )
+    assert isinstance(captured["auth"], NoneAuth)
 
-    assert http_mock.post.call_args.kwargs["auth"] is None
+
+# ---------------------------------------------------------------------------
+# Test helpers
+# ---------------------------------------------------------------------------
 
 
 def _mock_json_response(body: dict) -> MagicMock:
@@ -183,10 +172,58 @@ def _mock_json_response(body: dict) -> MagicMock:
     return response
 
 
-def _http_mock(json_bodies: list[dict]) -> MagicMock:
+def _http_client_mock(json_bodies: list[dict]) -> MagicMock:
+    """Mock httpx.AsyncClient passed in for resource metadata fetch."""
     mock = MagicMock()
     mock.get = AsyncMock(
         side_effect=[_mock_json_response(b) for b in json_bodies]
     )
-    mock.aclose = AsyncMock()
     return mock
+
+
+def _patch_callback_and_browser(monkeypatch, *, code: str) -> MagicMock:
+    callback_mock = MagicMock(spec=OAuthCallbackServer)
+    callback_mock.start = AsyncMock()
+    callback_mock.wait_for_code = AsyncMock(return_value=code)
+    callback_mock.stop = MagicMock()
+    monkeypatch.setattr(
+        "keycardai.oauth.pkce.client.OAuthCallbackServer",
+        lambda port: callback_mock,
+    )
+    monkeypatch.setattr(
+        "keycardai.oauth.pkce.client.webbrowser.open", lambda url: None
+    )
+    return callback_mock
+
+
+def _async_client_factory(
+    *,
+    endpoints: MagicMock,
+    exchange_response: TokenResponse | None = None,
+    capture: dict | None = None,
+):
+    """Build a stand-in for keycardai.oauth.AsyncClient.
+
+    Captures the constructor kwargs and the exchange_authorization_code call
+    so tests can assert against them.
+    """
+
+    def factory(base_url, *, auth, config):
+        if capture is not None:
+            capture["base_url"] = base_url
+            capture["auth"] = auth
+            capture["config"] = config
+        instance = MagicMock()
+        instance.get_endpoints = AsyncMock(return_value=endpoints)
+
+        async def _exchange(**kwargs):
+            if capture is not None:
+                capture["exchange_kwargs"] = kwargs
+            return exchange_response
+
+        instance.exchange_authorization_code = _exchange
+        instance.__aenter__ = AsyncMock(return_value=instance)
+        instance.__aexit__ = AsyncMock(return_value=None)
+        return instance
+
+    return factory

--- a/packages/oauth/tests/keycardai/oauth/pkce/test_client.py
+++ b/packages/oauth/tests/keycardai/oauth/pkce/test_client.py
@@ -1,0 +1,185 @@
+"""Tests for keycardai.oauth.pkce.PKCEClient.
+
+Mocks httpx and the local callback server to drive the full authentication
+flow without opening a browser.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from keycardai.oauth.pkce import OAuthCallbackServer, PKCEClient
+from keycardai.oauth.pkce.client import _extract_resource_metadata_url
+
+WWW_AUTHENTICATE = (
+    'Bearer error="invalid_token", '
+    'error_description="No bearer token", '
+    'resource_metadata="https://api.example.com/.well-known/oauth-protected-resource"'
+)
+
+
+def test_extract_resource_metadata_url_finds_url():
+    url = _extract_resource_metadata_url(WWW_AUTHENTICATE)
+    assert url == "https://api.example.com/.well-known/oauth-protected-resource"
+
+
+def test_extract_resource_metadata_url_returns_none_when_missing():
+    assert _extract_resource_metadata_url('Bearer error="invalid_token"') is None
+
+
+@pytest.mark.asyncio
+async def test_authenticate_raises_when_header_has_no_metadata_url():
+    async with PKCEClient(client_id="cid") as pkce:
+        with pytest.raises(ValueError, match="No resource_metadata"):
+            await pkce.authenticate(
+                resource_url="https://api.example.com",
+                www_authenticate_header='Bearer error="invalid_token"',
+            )
+
+
+@pytest.mark.asyncio
+async def test_authenticate_raises_when_metadata_has_no_auth_servers():
+    async with PKCEClient(client_id="cid") as pkce:
+        pkce._http = MagicMock(
+            get=AsyncMock(return_value=_mock_json_response({"authorization_servers": []})),
+            aclose=AsyncMock(),
+        )
+        with pytest.raises(ValueError, match="No authorization_servers"):
+            await pkce.authenticate(
+                resource_url="https://api.example.com",
+                www_authenticate_header=WWW_AUTHENTICATE,
+            )
+
+
+@pytest.mark.asyncio
+async def test_authenticate_raises_when_auth_server_missing_endpoints():
+    async with PKCEClient(client_id="cid") as pkce:
+        pkce._http = _http_mock(
+            [
+                {"authorization_servers": ["https://auth.example.com"]},
+                {"issuer": "https://auth.example.com"},  # no endpoints
+            ]
+        )
+        with pytest.raises(ValueError, match="Missing authorization_endpoint"):
+            await pkce.authenticate(
+                resource_url="https://api.example.com",
+                www_authenticate_header=WWW_AUTHENTICATE,
+            )
+
+
+@pytest.mark.asyncio
+async def test_authenticate_completes_full_flow(monkeypatch):
+    """Drives the happy path with mocked metadata, callback, and token endpoint."""
+    callback_mock = MagicMock(spec=OAuthCallbackServer)
+    callback_mock.start = AsyncMock()
+    callback_mock.wait_for_code = AsyncMock(return_value="auth-code-123")
+    callback_mock.stop = MagicMock()
+    monkeypatch.setattr(
+        "keycardai.oauth.pkce.client.OAuthCallbackServer",
+        lambda port: callback_mock,
+    )
+    monkeypatch.setattr("keycardai.oauth.pkce.client.webbrowser.open", lambda url: None)
+
+    token_response_body = {
+        "access_token": "downstream-token",
+        "token_type": "Bearer",
+        "expires_in": 3600,
+    }
+    http_mock = MagicMock()
+    http_mock.get = AsyncMock(
+        side_effect=[
+            _mock_json_response(
+                {"authorization_servers": ["https://auth.example.com"]}
+            ),
+            _mock_json_response(
+                {
+                    "authorization_endpoint": "https://auth.example.com/authorize",
+                    "token_endpoint": "https://auth.example.com/token",
+                }
+            ),
+        ]
+    )
+    http_mock.post = AsyncMock(return_value=_mock_json_response(token_response_body))
+    http_mock.aclose = AsyncMock()
+
+    async with PKCEClient(
+        client_id="my-app", client_secret="secret"
+    ) as pkce:
+        pkce._http = http_mock
+        result = await pkce.authenticate(
+            resource_url="https://api.example.com",
+            www_authenticate_header=WWW_AUTHENTICATE,
+        )
+
+    assert result == token_response_body
+    # Browser was opened, callback served, token exchanged.
+    callback_mock.start.assert_called_once()
+    callback_mock.wait_for_code.assert_called_once()
+    callback_mock.stop.assert_called_once()
+    http_mock.post.assert_called_once()
+    posted = http_mock.post.call_args
+    assert posted.args[0] == "https://auth.example.com/token"
+    assert posted.kwargs["data"]["grant_type"] == "authorization_code"
+    assert posted.kwargs["data"]["code"] == "auth-code-123"
+    assert posted.kwargs["data"]["resource"] == "https://api.example.com"
+    assert posted.kwargs["data"]["client_id"] == "my-app"
+    # Confidential client uses HTTP Basic auth on the token endpoint.
+    assert posted.kwargs["auth"] == ("my-app", "secret")
+
+
+@pytest.mark.asyncio
+async def test_authenticate_omits_basic_auth_for_public_client(monkeypatch):
+    callback_mock = MagicMock(spec=OAuthCallbackServer)
+    callback_mock.start = AsyncMock()
+    callback_mock.wait_for_code = AsyncMock(return_value="code")
+    callback_mock.stop = MagicMock()
+    monkeypatch.setattr(
+        "keycardai.oauth.pkce.client.OAuthCallbackServer",
+        lambda port: callback_mock,
+    )
+    monkeypatch.setattr("keycardai.oauth.pkce.client.webbrowser.open", lambda url: None)
+
+    http_mock = MagicMock()
+    http_mock.get = AsyncMock(
+        side_effect=[
+            _mock_json_response(
+                {"authorization_servers": ["https://auth.example.com"]}
+            ),
+            _mock_json_response(
+                {
+                    "authorization_endpoint": "https://auth.example.com/authorize",
+                    "token_endpoint": "https://auth.example.com/token",
+                }
+            ),
+        ]
+    )
+    http_mock.post = AsyncMock(
+        return_value=_mock_json_response({"access_token": "tok"})
+    )
+    http_mock.aclose = AsyncMock()
+
+    async with PKCEClient(client_id="public-app") as pkce:
+        pkce._http = http_mock
+        await pkce.authenticate(
+            resource_url="https://api.example.com",
+            www_authenticate_header=WWW_AUTHENTICATE,
+        )
+
+    assert http_mock.post.call_args.kwargs["auth"] is None
+
+
+def _mock_json_response(body: dict) -> MagicMock:
+    response = MagicMock(spec=httpx.Response)
+    response.json.return_value = body
+    response.raise_for_status.return_value = None
+    return response
+
+
+def _http_mock(json_bodies: list[dict]) -> MagicMock:
+    mock = MagicMock()
+    mock.get = AsyncMock(
+        side_effect=[_mock_json_response(b) for b in json_bodies]
+    )
+    mock.aclose = AsyncMock()
+    return mock

--- a/packages/oauth/tests/keycardai/oauth/pkce/test_client.py
+++ b/packages/oauth/tests/keycardai/oauth/pkce/test_client.py
@@ -117,6 +117,13 @@ async def test_authenticate_completes_full_flow(monkeypatch):
     callback_mock.start.assert_called_once()
     callback_mock.wait_for_code.assert_called_once()
     callback_mock.stop.assert_called_once()
+    # Discovery: resource metadata first, then RFC 8414 authorization server metadata.
+    assert http_mock.get.call_args_list[0].args[0] == (
+        "https://api.example.com/.well-known/oauth-protected-resource"
+    )
+    assert http_mock.get.call_args_list[1].args[0] == (
+        "https://auth.example.com/.well-known/oauth-authorization-server"
+    )
     http_mock.post.assert_called_once()
     posted = http_mock.post.call_args
     assert posted.args[0] == "https://auth.example.com/token"


### PR DESCRIPTION
## Summary

First step of the `keycardai-agents` decomposition (ACC-229..232). Per the revised KEP, the OAuth PKCE user-login flow is generic OAuth code with no agents-specific concerns and belongs in `keycardai-oauth` next to the rest of the OAuth client primitives.

## What ships

**New `keycardai.oauth.pkce` module:**

- `authenticate(...)` is a module-level async function that drives the full authorization-code-with-PKCE flow:
  - Parses the `WWW-Authenticate` challenge (RFC 9728)
  - Fetches the protected resource metadata document
  - Drives `keycardai.oauth.AsyncClient` against the discovered authorization server for server metadata discovery (RFC 8414) and code exchange
  - Generates the PKCE pair and CSRF state, opens the browser at the authorize endpoint
  - Captures the redirect via a local loopback callback server (RFC 8252)
  - Returns `TokenResponse`
- `OAuthCallbackServer` is the loopback redirect catcher used by `authenticate`; exported separately so callers running their own flow on top of the lower-level primitives can reuse the callback machinery.

**`AsyncClient` / `Client` gain an optional `resource` kwarg on `exchange_authorization_code`** (and on the underlying `operations._authorize` helpers). RFC 8707 resource indicators are now first-class on the canonical token-exchange path, which is what the PKCE flow uses internally.

**`keycardai-agents` changes:**

- `AgentClient.authenticate` now calls `keycardai.oauth.pkce.authenticate(...)` per `/invoke` retry, returning the access token string and updating the per-service token cache. No cached PKCE instance, no shared state.
- `AgentClient` drops ~370 lines of duplicated PKCE/discovery/callback code.
- `keycardai.agents.client.oauth` re-exports `OAuthCallbackServer` through a module `__getattr__` that emits a `DeprecationWarning` pointing at the new canonical import path.

## Why a function and not a class

Per [Kamil's review](https://github.com/keycardai/python-sdk/pull/101#discussion_r3148109284): a separate `PKCEClient` sitting next to `AsyncClient` invited "which client do I use?" The OAuth-server-facing operations (server metadata discovery, code exchange) belong on the existing `AsyncClient` instead of on a peer client. The PKCE module retains only what does not belong on `AsyncClient`: the user-flow orchestration (RFC 9728 challenge parsing, resource metadata fetch, browser launch, loopback callback server). `AsyncClient` is now the only thing in `keycardai.oauth` that talks to OAuth servers as a client.

## Test plan

- [x] 7 tests in `packages/oauth/tests/keycardai/oauth/pkce/test_client.py`:
  - `WWW-Authenticate` header parsing (present + missing)
  - Discovery error paths (no resource_metadata, no authorization_servers, missing endpoints on the auth server)
  - Happy-path flow with mocked resource metadata + AsyncClient + callback, asserts the RFC 8707 `resource` indicator is sent on the token request and HTTP Basic auth is configured for confidential clients
  - Public client uses `NoneAuth` on the token endpoint
- [x] keycardai-oauth: 215/215 passing (was 208 + 7 new)
- [x] keycardai-agents: 81/81 passing (was 85 - 4 removed implementation tests)
- [x] keycardai-mcp: 560/560 unaffected
- [x] keycardai-starlette: 49/49 unaffected
- [x] ruff clean

## Removed tests, justified

`test_agent_client_oauth.py::TestOAuthDiscoveryMethods` exercised private methods on `AgentClient` (`_extract_resource_metadata_url`, `_fetch_resource_metadata`, `_fetch_authorization_server_metadata`). Those methods are gone from `AgentClient`; equivalent contracts are tested in `test_client.py` in the keycardai-oauth suite. The `TestAgentClientInit`, `TestInvokeWithoutAuth`, and `TestContextManager` classes covering `AgentClient`'s public surface stay.

## Follow-up tickets

- ACC-230: extract `AgentServer` / `DelegationClient` / `ServiceDiscovery` into new `keycardai-a2a` package
- ACC-231: extract CrewAI integration into new `keycardai-crewai` package
- ACC-232: archive `packages/agents/` source directory