### PR TITLE
fix(ci): grant pull-requests: write to bump-packages caller

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,6 +49,7 @@ jobs:
     needs: detect-changes
     permissions:
       contents: write
+      pull-requests: write
     strategy:
       matrix:
         package: ${{ fromJson(needs.detect-changes.outputs.changed-packages) }}


### PR DESCRIPTION
Follow-up to #110.

The new bump-package.yml asks for `pull-requests: write` (so the script can `gh pr create`). The calling workflow `main.yml` was only granting `contents: write` to the `bump-packages` job, which made GitHub fail workflow validation:

```
Error calling workflow '.../bump-package.yml@...'.
The nested job 'bump' is requesting 'pull-requests: write',
but is only allowed 'pull-requests: none'.
```

Called workflows can only request permissions the caller has already granted. Adds `pull-requests: write` to the `bump-packages` job in `main.yml` so the called workflow inherits both write scopes.

After merge, the next change to a package on main should fire a successful bump-via-PR end-to-end.