### PR TITLE
bump: keycardai-a2a → 0.3.0

### DIFF
--- a/packages/a2a/CHANGELOG.md
+++ b/packages/a2a/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.3.0-keycardai-a2a (2026-05-01)
+
+
+- fix(keycardai-a2a)!: align DelegationClient with a2a-sdk 1.x JSONRPC dispatcher (ACC-231) (#107)
+- DelegationClient was still speaking 0.x JSON-RPC (“message/send”, old envelope, no A2A-Version), so every call was rejected by real 1.x dispatchers before execution—breaking the entire keycardai-crewai delegation path. Fixed by upgrading to the 1.x contract (SendMessage, proper envelope + headers, new response shape) and adding a real dispatcher test to catch drift.
+
 ## 0.2.0-keycardai-a2a (2026-04-29)
 
 

--- a/packages/a2a/pyproject.toml
+++ b/packages/a2a/pyproject.toml
@@ -96,7 +96,7 @@ asyncio_default_fixture_loop_scope = "function"
 
 [tool.commitizen]
 name = "cz_customize"
-version = "0.2.0"
+version = "0.3.0"
 tag_format = "${version}-keycardai-a2a"
 ignored_tag_formats = ["${version}-*"]
 update_changelog_on_bump = true


### PR DESCRIPTION
Auto-bump for `keycardai-a2a` to `0.3.0`.

Generated by `scripts/bump_package.py`. The branch tag will be created at the squash-merge SHA after this PR merges, which triggers the publish workflow.