### PR TITLE
bump: keycardai-starlette → 0.4.0

### DIFF
--- a/packages/starlette/CHANGELOG.md
+++ b/packages/starlette/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.4.0-keycardai-starlette (2026-05-01)
+
+
+- refactor(keycardai-starlette)!: remove deprecated BearerAuthMiddleware shims (ACC-237) (#109)
+- Removed deprecated BearerAuthMiddleware shims after all consumers migrated to AuthenticationMiddleware + KeycardAuthBackend, eliminating unused auth code. This is a breaking change—imports for BearerAuthMiddleware and verify_bearer_token now fail.
+
 ## 0.3.0-keycardai-starlette (2026-04-27)
 
 

--- a/packages/starlette/pyproject.toml
+++ b/packages/starlette/pyproject.toml
@@ -114,7 +114,7 @@ addopts = "-ra -q"
 
 [tool.commitizen]
 name = "cz_customize"
-version = "0.3.0"
+version = "0.4.0"
 tag_format = "${version}-keycardai-starlette"
 ignored_tag_formats = ["${version}-*"]
 update_changelog_on_bump = true


### PR DESCRIPTION
Auto-bump for `keycardai-starlette` to `0.4.0`.

Generated by `scripts/bump_package.py`. The branch tag will be created at the squash-merge SHA after this PR merges, which triggers the publish workflow.