### PR TITLE
chore: list workspace members explicitly to prevent stub-dir blowup

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -94,10 +94,13 @@ just build
 
 ### Adding a new package
 
-1. Create a new directory in `packages/`
-2. Initialize the package: `uv init packages/your-package-name`
-3. Update the package's `pyproject.toml` with appropriate metadata
-4. The package will automatically be included in the workspace
+1. Create the package directory in `packages/` and write its `pyproject.toml` before any source files.
+2. Register the package in the root `pyproject.toml`:
+   - Add `"packages/your-package-name"` to `[tool.uv.workspace] members`.
+   - Add `keycardai-your-package-name = { workspace = true }` under `[tool.uv.sources]`.
+3. Run `uv lock` to update the workspace lockfile.
+
+Workspace members are listed explicitly (no `packages/*` glob) so a half-bootstrapped or stray directory under `packages/` cannot accidentally enter the workspace.
 
 ## Package Structure
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,12 +49,17 @@ Repository = "https://github.com/keycardai/python-sdk"
 Issues = "https://github.com/keycardai/python-sdk/issues"
 
 [tool.uv.workspace]
+# Listed explicitly so stray or half-bootstrapped dirs under packages/ cannot leak in.
 members = [
     ".",
-    "packages/*",
-    "packages/*/examples/*"
+    "packages/oauth",
+    "packages/starlette",
+    "packages/mcp",
+    "packages/mcp-fastmcp",
+    "packages/fastmcp",
+    "packages/a2a",
+    "packages/*/examples/*",
 ]
-# Exclude any packages that shouldn't be part of the workspace
 exclude = []
 
 [tool.uv.sources]


### PR DESCRIPTION
## Summary
- Replaces the top-level `packages/*` workspace glob with an explicit list of active package directories
- Keeps the existing `packages/*/examples/*` glob because current example projects each have `pyproject.toml`
- Updates `DEVELOPER.md` so new packages are explicitly registered in the workspace and sources

## Why
A broad top-level `packages/*` glob can sweep in stale branch leftovers or half-bootstrapped package dirs that do not have `pyproject.toml`. This checkout already has ignored `packages/agents` and `packages/crewai` directories, which matches the class of workspace failure Matte flagged.

Listing active top-level packages explicitly makes the workspace package set closed and predictable while preserving the existing examples behavior.

## Verified
- `uv lock --check`
- `uv build --all-packages --out-dir /private/tmp/keycard-build-check`

## Notes
- Pending `keycardai-crewai` work should add `"packages/crewai"` to `[tool.uv.workspace] members` when that package is ready to join the workspace.
- The example workspace glob remains intentional; a future PR can make examples explicit too if we want the same hardening there.