### PR TITLE
ci: use GH App token and wait for stable PR state before auto-merge

### DIFF
--- a/.github/workflows/bump-package.yml
+++ b/.github/workflows/bump-package.yml
@@ -25,10 +25,17 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Generate GitHub App token
+        id: generate-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.GH_REPO_ACCESS_APP_ID }}
+          private-key: ${{ secrets.GH_REPO_ACCESS_PRIVATE_KEY }}
+
       - name: Checkout Repository
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.RELEASE_GITHUB_PAT }}
+          token: ${{ steps.generate-token.outputs.token }}
           fetch-depth: 0
 
       - name: Install uv
@@ -39,6 +46,6 @@ jobs:
 
       - name: Bump version for ${{ inputs.package_name }}
         env:
-          GH_TOKEN: ${{ secrets.RELEASE_GITHUB_PAT }}
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           uv run python scripts/bump_package.py "${{ inputs.package_name }}" "${{ inputs.package_dir }}"

--- a/scripts/bump_package.py
+++ b/scripts/bump_package.py
@@ -232,6 +232,27 @@ def create_signed_commit_on_branch(
     return True
 
 
+def wait_for_pr_stable(pr_number: int, timeout_seconds: int = 120) -> bool:
+    """Poll mergeStateStatus until GitHub has a definite state for the PR.
+
+    A freshly opened PR starts as UNKNOWN or UNSTABLE while required checks
+    register. Auto-merge can only be enabled once the PR leaves that limbo.
+    """
+    deadline = time.time() + timeout_seconds
+    while time.time() < deadline:
+        exit_code, stdout, _ = run_command(
+            ["gh", "pr", "view", str(pr_number), "--json", "mergeStateStatus"]
+        )
+        if exit_code == 0:
+            state = json.loads(stdout).get("mergeStateStatus", "")
+            print(f"PR #{pr_number} merge state: {state}")
+            if state not in ("UNKNOWN", "UNSTABLE"):
+                return True
+        time.sleep(5)
+    print(f"Timed out waiting for PR #{pr_number} to reach a stable merge state")
+    return False
+
+
 def create_pr_with_automerge(
     branch: str, package_name: str, new_version: str
 ) -> int | None:
@@ -274,6 +295,9 @@ def create_pr_with_automerge(
         return None
     pr_number = int(pr_number_match.group(1))
     print(f"Opened PR #{pr_number}: {pr_url}")
+
+    if not wait_for_pr_stable(pr_number):
+        return None
 
     print("Enabling auto-merge (squash)...")
     exit_code, _, stderr = run_command(


### PR DESCRIPTION
## Summary
- Replaces \`RELEASE_GITHUB_PAT\` with a short-lived GitHub App token via \`actions/create-github-app-token@v2\` (matching the pattern already used in \`service-sync.yml\`)
- Adds \`wait_for_pr_stable()\` to poll \`mergeStateStatus\` before enabling auto-merge — GitHub returns \"unstable status\" if required checks haven't registered yet on a freshly opened PR

## Context
Both fixes were discovered and validated while shipping the same PR-native bump flow to \`typescript-sdk\`. Porting them here to keep the two SDKs in sync.