### PR TITLE
ci: add Socket Fix autopilot

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   validate-commits:
     runs-on: ubuntu-latest
+    if: github.event.pull_request.user.type != 'Bot'
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4

--- a/.github/workflows/socket-fix.yml
+++ b/.github/workflows/socket-fix.yml
@@ -1,0 +1,46 @@
+name: Socket Fix
+
+on:
+  schedule:
+    - cron: "17 6 * * 1,4" # Mon + Thu 6:17am UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  fix:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate GitHub App token
+        id: generate-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.GH_REPO_ACCESS_APP_ID }}
+          private-key: ${{ secrets.GH_REPO_ACCESS_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - uses: astral-sh/setup-uv@v4
+
+      - name: Install dependencies
+        run: uv sync --all-extras --all-packages
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Run Socket Fix
+        env:
+          SOCKET_CLI_GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+          SOCKET_CLI_API_TOKEN: ${{ secrets.SOCKET_API_TOKEN }}
+          SOCKET_CLI_GIT_USER_NAME: github-actions[bot]
+          SOCKET_CLI_GIT_USER_EMAIL: 41898282+github-actions[bot]@users.noreply.github.com
+        run: npx @socketsecurity/cli fix --autopilot


### PR DESCRIPTION
## Summary
- Adds \`socket-fix.yml\` — runs Socket Fix in autopilot mode twice weekly (Mon + Thu), with \`workflow_dispatch\` for manual runs
- Uses the GH App token (same \`GH_REPO_ACCESS_APP_ID\`/\`GH_REPO_ACCESS_PRIVATE_KEY\` already wired up for the bump workflow) so no new long-lived credentials are needed
- Passes the generated token as \`SOCKET_CLI_GITHUB_TOKEN\` — Socket opens fix PRs as the app identity, which ensures \`pr.yml\` CI checks run on those PRs and auto-merge can trigger
- Exempts bot-opened PRs from conventional commit validation in \`pr.yml\` (one-line \`if\` condition on \`validate-commits\` job) — Socket's dependency upgrade commits won't follow conventional format and shouldn't need to

## New secret needed
\`SOCKET_API_TOKEN\` — Socket's API key, needs to be added to this repo.

## How it fits the release process
Socket fix PRs flow through the same auto-merge pipeline as bump PRs. No special cases.