### PR TITLE
fix(oauth): validate discovery issuer matches the requested URL (RFC 8414 §3.3)

### DIFF
--- a/packages/oauth/src/keycardai/oauth/operations/_discovery.py
+++ b/packages/oauth/src/keycardai/oauth/operations/_discovery.py
@@ -98,7 +98,11 @@ def parse_discovery_http_response(
         )
 
     if "issuer" not in data:
-        raise ValueError("Authorization server metadata must include 'issuer' field")
+        raise OAuthProtocolError(
+            error="invalid_response",
+            error_description="Authorization server metadata must include 'issuer' field",
+            operation="GET /.well-known/oauth-authorization-server",
+        )
 
     if expected_issuer is not None and data["issuer"].rstrip("/") != expected_issuer.rstrip("/"):
         raise OAuthProtocolError(

--- a/packages/oauth/src/keycardai/oauth/operations/_discovery.py
+++ b/packages/oauth/src/keycardai/oauth/operations/_discovery.py
@@ -52,18 +52,23 @@ def build_discovery_http_request(
     )
 
 
-def parse_discovery_http_response(res: HttpResponse) -> AuthorizationServerMetadata:
+def parse_discovery_http_response(
+    res: HttpResponse, expected_issuer: str | None = None
+) -> AuthorizationServerMetadata:
     """Parse HTTP response from server metadata discovery.
 
     Args:
         res: HTTP response from discovery endpoint
+        expected_issuer: The issuer the request was built from. When provided,
+            the response ``issuer`` must match it (RFC 8414 Section 3.3); a
+            trailing slash is ignored on both sides.
 
     Returns:
         AuthorizationServerMetadata with discovered server capabilities
 
     Raises:
         OAuthHttpError: If HTTP error status
-        OAuthProtocolError: If invalid response format
+        OAuthProtocolError: If invalid response format or issuer mismatch
     """
     # TODO: Handle errors more granularly
     if res.status >= 400:
@@ -94,6 +99,16 @@ def parse_discovery_http_response(res: HttpResponse) -> AuthorizationServerMetad
 
     if "issuer" not in data:
         raise ValueError("Authorization server metadata must include 'issuer' field")
+
+    if expected_issuer is not None and data["issuer"].rstrip("/") != expected_issuer.rstrip("/"):
+        raise OAuthProtocolError(
+            error="issuer_mismatch",
+            error_description=(
+                f"Discovery document issuer '{data['issuer']}' does not match "
+                f"the requested issuer '{expected_issuer}'"
+            ),
+            operation="GET /.well-known/oauth-authorization-server",
+        )
 
     def normalize_array_field(field_name: str) -> list[str] | None:
         value = data.get(field_name)
@@ -165,7 +180,7 @@ def discover_server_metadata(
     """
     http_req = build_discovery_http_request(request, context)
     http_res = context.transport.request_raw(http_req, timeout=context.timeout)
-    return parse_discovery_http_response(http_res)
+    return parse_discovery_http_response(http_res, expected_issuer=request.base_url)
 
 
 async def discover_server_metadata_async(
@@ -194,4 +209,4 @@ async def discover_server_metadata_async(
     """
     http_req = build_discovery_http_request(request, context)
     http_res = await context.transport.request_raw(http_req, timeout=context.timeout)
-    return parse_discovery_http_response(http_res)
+    return parse_discovery_http_response(http_res, expected_issuer=request.base_url)

--- a/packages/oauth/tests/keycardai/oauth/operations/test_discovery.py
+++ b/packages/oauth/tests/keycardai/oauth/operations/test_discovery.py
@@ -84,6 +84,17 @@ class TestDiscoveryOperations:
         with pytest.raises(OAuthProtocolError, match="Invalid JSON"):
             parse_discovery_http_response(http_response)
 
+    def test_parse_discovery_http_response_missing_issuer(self):
+        """Missing issuer raises the typed protocol error, not a bare ValueError."""
+        http_response = HttpResponse(
+            status=200,
+            headers={"Content-Type": "application/json"},
+            body=b'{"token_endpoint": "https://auth.example.com/token"}'
+        )
+
+        with pytest.raises(OAuthProtocolError, match="issuer"):
+            parse_discovery_http_response(http_response)
+
     def test_parse_discovery_http_response_issuer_mismatch(self):
         """Issuer in the document must match the requested issuer (RFC 8414 Section 3.3)."""
         http_response = HttpResponse(

--- a/packages/oauth/tests/keycardai/oauth/operations/test_discovery.py
+++ b/packages/oauth/tests/keycardai/oauth/operations/test_discovery.py
@@ -84,6 +84,58 @@ class TestDiscoveryOperations:
         with pytest.raises(OAuthProtocolError, match="Invalid JSON"):
             parse_discovery_http_response(http_response)
 
+    def test_parse_discovery_http_response_issuer_mismatch(self):
+        """Issuer in the document must match the requested issuer (RFC 8414 Section 3.3)."""
+        http_response = HttpResponse(
+            status=200,
+            headers={"Content-Type": "application/json"},
+            body=b'{"issuer": "https://evil.example.com"}'
+        )
+
+        with pytest.raises(OAuthProtocolError, match="issuer"):
+            parse_discovery_http_response(
+                http_response, expected_issuer="https://auth.example.com"
+            )
+
+    def test_parse_discovery_http_response_issuer_match_ignores_trailing_slash(self):
+        """A trailing slash difference is not a mismatch."""
+        http_response = HttpResponse(
+            status=200,
+            headers={"Content-Type": "application/json"},
+            body=b'{"issuer": "https://auth.example.com"}'
+        )
+
+        result = parse_discovery_http_response(
+            http_response, expected_issuer="https://auth.example.com/"
+        )
+
+        assert result.issuer == "https://auth.example.com"
+
+    def test_discover_server_metadata_rejects_issuer_mismatch(self):
+        """The discovery operation validates the issuer against the request."""
+        mock_transport = Mock()
+        mock_transport.request_raw.return_value = HttpResponse(
+            status=200,
+            headers={"Content-Type": "application/json"},
+            body=b'{"issuer": "https://evil.example.com"}'
+        )
+
+        mock_auth = Mock()
+        mock_auth.apply_headers.return_value = {}
+
+        context = build_http_context(
+            endpoint="https://auth.example.com/.well-known/oauth-authorization-server",
+            transport=mock_transport,
+            auth=mock_auth,
+            user_agent="TestClient/1.0",
+            timeout=30.0
+        )
+
+        req = ServerMetadataRequest(base_url="https://auth.example.com")
+
+        with pytest.raises(OAuthProtocolError, match="issuer"):
+            discover_server_metadata(req, context)
+
     def test_discover_server_metadata_sync(self):
         """Test synchronous discovery operation."""
         mock_transport = Mock()


### PR DESCRIPTION
Discovery previously only checked that the metadata `issuer` field was *present*, never that it matched the requested URL. A misconfigured or substituted authorization-server document was therefore accepted silently. The TypeScript SDK already performs this check.

## Change
- `parse_discovery_http_response` accepts an optional `expected_issuer`; on mismatch it raises `OAuthProtocolError(error="issuer_mismatch")`.
- `discover_server_metadata` and `discover_server_metadata_async` pass `request.base_url`.
- A trailing slash is ignored on both sides.

## Tests
3 new tests (direct mismatch, trailing-slash match, operation-level rejection). Full discovery suite passes (9/9).

Part of the SDK parity effort. Closes ECO-27.