### PR TITLE
refactor(keycardai-oauth)!: name the authorization server URL `issuer`, deprecate `base_url`

### DIFF
--- a/packages/oauth/src/keycardai/oauth/client.py
+++ b/packages/oauth/src/keycardai/oauth/client.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import threading
+import warnings
 from typing import Any, overload
 
 from .exceptions import (
@@ -54,15 +55,53 @@ from .types.oauth import (
 from .utils.jwt import build_substitute_user_token
 
 
+def _resolve_issuer_arg(issuer: str | None, base_url: str | None) -> str:
+    """Resolve the canonical issuer from the ``issuer`` / deprecated ``base_url`` args.
+
+    Emits a ``DeprecationWarning`` when ``base_url`` is supplied. Raises
+    ``ConfigError`` if both are supplied or neither resolves to a value.
+    """
+    if base_url is not None:
+        warnings.warn(
+            "`base_url` is deprecated; use `issuer` instead.",
+            DeprecationWarning,
+            stacklevel=3,
+        )
+        if issuer is not None:
+            raise ConfigError("Pass either `issuer` or `base_url`, not both.")
+        issuer = base_url
+    if not issuer:
+        raise ConfigError("issuer is required")
+    return issuer.rstrip("/")
+
+
+def _resolve_discovery_issuer(args: dict[str, Any], default_issuer: str) -> str:
+    """Resolve the issuer for a discovery call from its keyword args.
+
+    Accepts ``issuer`` (canonical) or ``base_url`` (deprecated), falling back to
+    the client's own issuer. Emits a ``DeprecationWarning`` for ``base_url``.
+    """
+    if "issuer" in args and "base_url" in args:
+        raise ConfigError("Pass either `issuer` or `base_url`, not both.")
+    if "base_url" in args:
+        warnings.warn(
+            "`base_url` is deprecated; use `issuer` instead.",
+            DeprecationWarning,
+            stacklevel=3,
+        )
+        return args["base_url"]
+    return args.get("issuer", default_issuer)
+
+
 def resolve_endpoints(
-    base_url: str,
+    issuer: str,
     endpoint_overrides: Endpoints | None = None,
     discovered_metadata: "AuthorizationServerMetadata | None" = None,
 ) -> Endpoints:
     """Resolve final endpoint URLs with priority: overrides > discovered > defaults.
 
     Args:
-        base_url: Base URL for OAuth 2.0 server
+        issuer: Issuer URL for the OAuth 2.0 authorization server
         endpoint_overrides: Optional endpoint overrides (highest priority)
         discovered_metadata: Optional discovered server metadata (middle priority)
 
@@ -94,17 +133,17 @@ def resolve_endpoints(
             endpoints.authorize = discovered_metadata.authorization_endpoint
 
     if not endpoints.introspect:
-        endpoints.introspect = OAuth2DefaultEndpoints.construct_url(base_url, OAuth2DefaultEndpoints.INTROSPECTION)
+        endpoints.introspect = OAuth2DefaultEndpoints.construct_url(issuer, OAuth2DefaultEndpoints.INTROSPECTION)
     if not endpoints.token:
-        endpoints.token = OAuth2DefaultEndpoints.construct_url(base_url, OAuth2DefaultEndpoints.TOKEN)
+        endpoints.token = OAuth2DefaultEndpoints.construct_url(issuer, OAuth2DefaultEndpoints.TOKEN)
     if not endpoints.revoke:
-        endpoints.revoke = OAuth2DefaultEndpoints.construct_url(base_url, OAuth2DefaultEndpoints.REVOCATION)
+        endpoints.revoke = OAuth2DefaultEndpoints.construct_url(issuer, OAuth2DefaultEndpoints.REVOCATION)
     if not endpoints.register:
-        endpoints.register = OAuth2DefaultEndpoints.construct_url(base_url, OAuth2DefaultEndpoints.REGISTRATION)
+        endpoints.register = OAuth2DefaultEndpoints.construct_url(issuer, OAuth2DefaultEndpoints.REGISTRATION)
     if not endpoints.authorize:
-        endpoints.authorize = OAuth2DefaultEndpoints.construct_url(base_url, OAuth2DefaultEndpoints.AUTHORIZATION)
+        endpoints.authorize = OAuth2DefaultEndpoints.construct_url(issuer, OAuth2DefaultEndpoints.AUTHORIZATION)
     if not endpoints.par:
-        endpoints.par = OAuth2DefaultEndpoints.construct_url(base_url, OAuth2DefaultEndpoints.PUSHED_AUTHORIZATION)
+        endpoints.par = OAuth2DefaultEndpoints.construct_url(issuer, OAuth2DefaultEndpoints.PUSHED_AUTHORIZATION)
 
     return endpoints
 
@@ -230,8 +269,9 @@ class AsyncClient:
 
     def __init__(
         self,
-        base_url: str,
+        issuer: str | None = None,
         *,
+        base_url: str | None = None,
         auth: AuthStrategy | None = None,
         endpoints: Endpoints | None = None,
         transport: AsyncHTTPTransport | None = None,
@@ -240,16 +280,14 @@ class AsyncClient:
         """Initialize asynchronous OAuth 2.0 client.
 
         Args:
-            base_url: Base URL for OAuth 2.0 server
+            issuer: Issuer URL of the OAuth 2.0 authorization server (RFC 8414).
+            base_url: Deprecated alias for ``issuer``.
             auth: Authentication strategy (BasicAuth, BearerAuth, NoneAuth)
             endpoints: Endpoint overrides for multi-server deployments
             transport: Custom asynchronous HTTP transport
             config: Client configuration with timeouts, retries, etc.
         """
-        if not base_url:
-            raise ConfigError("base_url is required")
-
-        self.base_url = base_url.rstrip("/")
+        self.issuer = _resolve_issuer_arg(issuer, base_url)
         self.config = config or ClientConfig()
 
         self.auth_strategy = auth or NoneAuth()
@@ -265,7 +303,7 @@ class AsyncClient:
 
         self._endpoint_overrides = endpoints
 
-        self._endpoints = resolve_endpoints(self.base_url, endpoints)
+        self._endpoints = resolve_endpoints(self.issuer, endpoints)
 
         self._initialized = False
         self._init_lock: asyncio.Lock | None = None
@@ -273,6 +311,11 @@ class AsyncClient:
         self._client_id = None
         self._client_secret = None
         self._discovered_endpoints: Endpoints | None = None
+
+    @property
+    def base_url(self) -> str:
+        """Deprecated alias for :attr:`issuer`. Use ``issuer`` instead."""
+        return self.issuer
 
     async def _ensure_initialized(self) -> None:
         """Ensure client is fully initialized with discovery and registration.
@@ -298,13 +341,13 @@ class AsyncClient:
                 try:
                     metadata = await self.discover_server_metadata()
                     self._discovered_endpoints = resolve_endpoints(
-                        self.base_url,
+                        self.issuer,
                         self._endpoint_overrides,
                         metadata
                     )
                 except (OAuthHttpError, OAuthProtocolError, NetworkError, AuthenticationError):
                     self._discovered_endpoints = resolve_endpoints(
-                        self.base_url,
+                        self.issuer,
                         self._endpoint_overrides,
                         None
                     )
@@ -524,7 +567,7 @@ class AsyncClient:
         self,
         /,
         *,
-        base_url: str | None = None,
+        issuer: str | None = None,
     ) -> AuthorizationServerMetadata: ...
 
     async def discover_server_metadata(self, request: ServerMetadataRequest | None = None, /, **metadata_discovery_args) -> AuthorizationServerMetadata:
@@ -539,23 +582,24 @@ class AsyncClient:
 
         With keyword arguments:
             metadata = await client.discover_server_metadata(
-                base_url="https://custom.auth.example.com"
+                issuer="https://custom.auth.example.com"
             )
 
         Explicit request:
-            request = ServerMetadataRequest(base_url="https://auth.example.com")
+            request = ServerMetadataRequest(issuer="https://auth.example.com")
             metadata = await client.discover_server_metadata(request)
 
         Args:
-            request: Optional ServerMetadataRequest (defaults to client's base_url if not provided)
-            **metadata_discovery_args: Alternative to request - provide individual parameters
+            request: Optional ServerMetadataRequest (defaults to the client's issuer if not provided)
+            **metadata_discovery_args: Alternative to request - provide ``issuer``
+                (``base_url`` is accepted as a deprecated alias)
 
         Returns:
             AuthorizationServerMetadata with discovered server capabilities
 
         Raises:
             TypeError: If both request and metadata_discovery_args are provided
-            ConfigError: If base_url is empty
+            ConfigError: If issuer is empty
             OAuthHttpError: If discovery endpoint is unreachable
             OAuthProtocolError: If metadata format is invalid
             NetworkError: If network request fails
@@ -564,11 +608,11 @@ class AsyncClient:
             raise TypeError("Pass either `request` or keyword arguments, not both.")
 
         if request is None:
-            base_url = metadata_discovery_args.get("base_url", self.base_url)
-            request = ServerMetadataRequest(base_url=base_url)
+            issuer = _resolve_discovery_issuer(metadata_discovery_args, self.issuer)
+            request = ServerMetadataRequest(issuer=issuer)
 
         context = build_http_context(
-            endpoint=self.base_url,
+            endpoint=self.issuer,
             transport=self.transport,
             auth=self.auth_strategy,
             user_agent=self.config.user_agent,
@@ -839,8 +883,9 @@ class Client:
 
     def __init__(
         self,
-        base_url: str,
+        issuer: str | None = None,
         *,
+        base_url: str | None = None,
         auth: AuthStrategy | None = None,
         endpoints: Endpoints | None = None,
         transport: HTTPTransport | None = None,
@@ -849,16 +894,14 @@ class Client:
         """Initialize synchronous OAuth 2.0 client.
 
         Args:
-            base_url: Base URL for OAuth 2.0 server
+            issuer: Issuer URL of the OAuth 2.0 authorization server (RFC 8414).
+            base_url: Deprecated alias for ``issuer``.
             auth: Authentication strategy (BasicAuth, BearerAuth, NoneAuth)
             endpoints: Endpoint overrides for multi-server deployments
             transport: Custom synchronous HTTP transport
             config: Client configuration with timeouts, retries, etc.
         """
-        if not base_url:
-            raise ConfigError("base_url is required")
-
-        self.base_url = base_url.rstrip("/")
+        self.issuer = _resolve_issuer_arg(issuer, base_url)
         self.config = config or ClientConfig()
 
         self.auth_strategy = auth or NoneAuth()
@@ -874,7 +917,7 @@ class Client:
 
         self._endpoint_overrides = endpoints
 
-        self._endpoints = resolve_endpoints(self.base_url, endpoints)
+        self._endpoints = resolve_endpoints(self.issuer, endpoints)
 
         # Lazy initialization state (thread-safe)
         self._initialized = False
@@ -884,6 +927,11 @@ class Client:
         self._client_id = None
         self._client_secret = None
         self._discovered_endpoints: Endpoints | None = None
+
+    @property
+    def base_url(self) -> str:
+        """Deprecated alias for :attr:`issuer`. Use ``issuer`` instead."""
+        return self.issuer
 
     def _ensure_initialized(self) -> None:
         """Ensure client is fully initialized with discovery and registration.
@@ -909,14 +957,14 @@ class Client:
                 try:
                     metadata = self.discover_server_metadata()
                     self._discovered_endpoints = resolve_endpoints(
-                        self.base_url,
+                        self.issuer,
                         self._endpoint_overrides,
                         metadata
                     )
                 except (OAuthHttpError, OAuthProtocolError, NetworkError, AuthenticationError):
                     # Discovery failed, use defaults
                     self._discovered_endpoints = resolve_endpoints(
-                        self.base_url,
+                        self.issuer,
                         self._endpoint_overrides,
                         None
                     )
@@ -1102,7 +1150,7 @@ class Client:
         self,
         /,
         *,
-        base_url: str | None = None,
+        issuer: str | None = None,
     ) -> AuthorizationServerMetadata: ...
 
     def discover_server_metadata(self, request: ServerMetadataRequest | None = None, /, **metadata_discovery_args) -> AuthorizationServerMetadata:
@@ -1117,16 +1165,17 @@ class Client:
 
         With keyword arguments:
             metadata = client.discover_server_metadata(
-                base_url="https://custom.auth.example.com"
+                issuer="https://custom.auth.example.com"
             )
 
         Explicit request:
-            request = ServerMetadataRequest(base_url="https://auth.example.com")
+            request = ServerMetadataRequest(issuer="https://auth.example.com")
             metadata = client.discover_server_metadata(request)
 
         Args:
-            request: Optional ServerMetadataRequest (defaults to client's base_url if not provided)
-            **metadata_discovery_args: Alternative to request - provide individual parameters
+            request: Optional ServerMetadataRequest (defaults to the client's issuer if not provided)
+            **metadata_discovery_args: Alternative to request - provide ``issuer``
+                (``base_url`` is accepted as a deprecated alias)
 
         Returns:
             AuthorizationServerMetadata with discovered server capabilities
@@ -1141,11 +1190,11 @@ class Client:
             raise TypeError("Pass either `request` or keyword arguments, not both.")
 
         if request is None:
-            base_url = metadata_discovery_args.get("base_url", self.base_url)
-            request = ServerMetadataRequest(base_url=base_url)
+            issuer = _resolve_discovery_issuer(metadata_discovery_args, self.issuer)
+            request = ServerMetadataRequest(issuer=issuer)
 
         context = build_http_context(
-            endpoint=self.base_url,
+            endpoint=self.issuer,
             transport=self.transport,
             auth=self.auth_strategy,
             user_agent=self.config.user_agent,

--- a/packages/oauth/src/keycardai/oauth/operations/_discovery.py
+++ b/packages/oauth/src/keycardai/oauth/operations/_discovery.py
@@ -31,7 +31,7 @@ def build_discovery_http_request(
     # Construct discovery URL according to RFC 8414 Section 3
     # Format: {issuer}/.well-known/oauth-authorization-server
     discovery_url = WellKnownEndpoint.construct_url(
-        request.base_url,
+        request.issuer,
         WellKnownEndpoint.OAUTH_AUTHORIZATION_SERVER
     )
 
@@ -184,7 +184,7 @@ def discover_server_metadata(
     """
     http_req = build_discovery_http_request(request, context)
     http_res = context.transport.request_raw(http_req, timeout=context.timeout)
-    return parse_discovery_http_response(http_res, expected_issuer=request.base_url)
+    return parse_discovery_http_response(http_res, expected_issuer=request.issuer)
 
 
 async def discover_server_metadata_async(
@@ -213,4 +213,4 @@ async def discover_server_metadata_async(
     """
     http_req = build_discovery_http_request(request, context)
     http_res = await context.transport.request_raw(http_req, timeout=context.timeout)
-    return parse_discovery_http_response(http_res, expected_issuer=request.base_url)
+    return parse_discovery_http_response(http_res, expected_issuer=request.issuer)

--- a/packages/oauth/src/keycardai/oauth/pkce/client.py
+++ b/packages/oauth/src/keycardai/oauth/pkce/client.py
@@ -118,7 +118,7 @@ async def authenticate(
     config = ClientConfig(enable_metadata_discovery=True, auto_register_client=False)
 
     async with AsyncClient(
-        base_url=auth_server_url, auth=auth_strategy, config=config
+        issuer=auth_server_url, auth=auth_strategy, config=config
     ) as oauth_client:
         endpoints = await oauth_client.get_endpoints()
         if not endpoints.authorize or not endpoints.token:

--- a/packages/oauth/src/keycardai/oauth/types/models.py
+++ b/packages/oauth/src/keycardai/oauth/types/models.py
@@ -12,7 +12,7 @@ OAuth 2.0 operations, providing comprehensive support for:
 from dataclasses import dataclass, field
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import AliasChoices, BaseModel, ConfigDict, Field
 
 from .oauth import (
     GrantType,
@@ -218,7 +218,19 @@ class ServerMetadataRequest(BaseModel):
     Reference: https://datatracker.ietf.org/doc/html/rfc8414#section-3
     """
 
-    base_url: str = Field(..., min_length=1, description="Base URL of the OAuth 2.0 authorization server.")
+    model_config = ConfigDict(populate_by_name=True)
+
+    issuer: str = Field(
+        ...,
+        min_length=1,
+        validation_alias=AliasChoices("issuer", "base_url"),
+        description="Issuer URL of the OAuth 2.0 authorization server (RFC 8414).",
+    )
+
+    @property
+    def base_url(self) -> str:
+        """Deprecated alias for :attr:`issuer`. Use ``issuer`` instead."""
+        return self.issuer
 
 
 @dataclass

--- a/packages/oauth/tests/keycardai/oauth/pkce/test_client.py
+++ b/packages/oauth/tests/keycardai/oauth/pkce/test_client.py
@@ -120,7 +120,7 @@ async def test_authenticate_completes_full_flow(monkeypatch):
     )
     # AsyncClient was constructed against the discovered authorization server
     # with HTTP Basic auth (confidential client).
-    assert captured["base_url"] == "https://auth.example.com"
+    assert captured["issuer"] == "https://auth.example.com"
     assert isinstance(captured["auth"], BasicAuth)
     assert captured["auth"].client_id == "my-app"
     assert captured["auth"].client_secret == "secret"
@@ -208,9 +208,9 @@ def _async_client_factory(
     so tests can assert against them.
     """
 
-    def factory(base_url, *, auth, config):
+    def factory(issuer=None, *, auth, config):
         if capture is not None:
-            capture["base_url"] = base_url
+            capture["issuer"] = issuer
             capture["auth"] = auth
             capture["config"] = config
         instance = MagicMock()

--- a/packages/oauth/tests/keycardai/oauth/test_client.py
+++ b/packages/oauth/tests/keycardai/oauth/test_client.py
@@ -6,6 +6,7 @@ import pytest
 from pydantic import ValidationError
 
 from keycardai.oauth import AsyncClient, Client, ClientConfig
+from keycardai.oauth.exceptions import ConfigError
 from keycardai.oauth.types.models import (
     AuthorizationServerMetadata,
     ClientRegistrationRequest,
@@ -115,6 +116,40 @@ class TestAsyncClientContextManager:
             async with client:
                 # Verify _ensure_initialized was called during context entry
                 mock_init.assert_called_once()
+
+
+class TestIssuerArgument:
+    """The canonical constructor parameter is `issuer`; `base_url` is a deprecated alias."""
+
+    @pytest.mark.parametrize("client_cls", [Client, AsyncClient])
+    def test_issuer_positional_and_keyword(self, client_cls):
+        config = ClientConfig(enable_metadata_discovery=False, auto_register_client=False)
+
+        positional = client_cls("https://test.example.com", config=config)
+        keyword = client_cls(issuer="https://test.example.com", config=config)
+
+        assert positional.issuer == "https://test.example.com"
+        assert keyword.issuer == "https://test.example.com"
+
+    @pytest.mark.parametrize("client_cls", [Client, AsyncClient])
+    def test_base_url_is_deprecated_alias(self, client_cls):
+        config = ClientConfig(enable_metadata_discovery=False, auto_register_client=False)
+
+        with pytest.warns(DeprecationWarning):
+            client = client_cls(base_url="https://test.example.com", config=config)
+
+        assert client.issuer == "https://test.example.com"
+        assert client.base_url == "https://test.example.com"
+
+    @pytest.mark.parametrize("client_cls", [Client, AsyncClient])
+    def test_issuer_and_base_url_together_is_an_error(self, client_cls):
+        with pytest.raises(ConfigError):
+            client_cls(issuer="https://a.example.com", base_url="https://b.example.com")
+
+    @pytest.mark.parametrize("client_cls", [Client, AsyncClient])
+    def test_missing_issuer_is_an_error(self, client_cls):
+        with pytest.raises(ConfigError):
+            client_cls()
 
 
 class TestClientInitializationParity:


### PR DESCRIPTION
RFC 8414 calls this value the *issuer*; the SDK called it `base_url`, which also diverged from the TypeScript SDK (`issuer`). This renames it across the client surface with full back-compat.

## Change
- `Client` / `AsyncClient` accept `issuer` (canonical) and `base_url` (deprecated alias → `DeprecationWarning`). A read-only `base_url` property mirrors `issuer`.
- `ServerMetadataRequest` field is `issuer`, with `base_url` accepted as a pydantic validation alias and exposed via a deprecated `base_url` property.
- `discover_server_metadata(issuer=...)`; `base_url=` still works (deprecated).
- Internal pkce client migrated to `issuer=`.

`base_url` keeps working for one release, so this is non-breaking now and marked `!` for the eventual removal.

## Tests
Full oauth suite passes (232). New `TestIssuerArgument`: positional/keyword `issuer`, `base_url` deprecation, both-supplied error, missing-issuer error. Ruff clean.

> **Stacked on #127** (ECO-27). Base retargets to `main` once #127 merges; review the top commit only.

Part of the SDK parity effort. Closes ECO-30.