### PR TITLE
feat(oauth): implement user impersonation via substitute-user token e…

### DIFF
--- a/packages/oauth/src/keycardai/oauth/client.py
+++ b/packages/oauth/src/keycardai/oauth/client.py
@@ -22,6 +22,10 @@ from .operations._authorize import (
     exchange_authorization_code as _exchange_authorization_code,
     exchange_authorization_code_async as _exchange_authorization_code_async,
 )
+from .operations._client_credentials import (
+    grant_client_credentials,
+    grant_client_credentials_async,
+)
 from .operations._discovery import (
     discover_server_metadata,
     discover_server_metadata_async,
@@ -726,23 +730,24 @@ class AsyncClient:
         self,
         *,
         user_identifier: str,
-        resource: str,
-        scope: str | None = None,
+        resource: str | None = None,
+        scopes: list[str] | None = None,
         timeout: float | None = None,
     ) -> TokenResponse:
         """Impersonate a user to obtain a resource token.
 
-        Performs an RFC 8693 token exchange using a substitute-user subject token.
-        The calling application must authenticate via client credentials and the
-        user must have previously established a delegated grant for the resource.
+        Performs an RFC 8693 token exchange where the actor token is derived
+        from the client's application credential (via a client_credentials
+        grant) and the subject token is an unsigned substitute-user JWT
+        carrying the target user identifier.
 
-        This is a privileged operation controlled by policy. Impersonation is
-        forbidden by default; an administrator must explicitly allow it.
+        Impersonation is a privileged operation controlled server-side by
+        Keycard policy and is forbidden by default.
 
         Args:
-            user_identifier: Stable user identifier (e.g. email, oid).
-            resource: Target resource URI (e.g. "https://graph.microsoft.com").
-            scope: Optional scope string for the requested token.
+            user_identifier: Target user (becomes ``sub`` in the issued token).
+            resource: Optional target resource URI for the issued token.
+            scopes: Optional list of scopes requested for the issued token.
             timeout: Optional request timeout override.
 
         Returns:
@@ -750,25 +755,11 @@ class AsyncClient:
 
         Raises:
             OAuthHttpError: If the token endpoint returns an HTTP error.
-            OAuthProtocolError: If the response contains an OAuth error.
-
-        Example:
-            async with AsyncClient(
-                "https://zone.keycard.cloud",
-                auth=BasicAuth("client_id", "client_secret"),
-            ) as client:
-                response = await client.impersonate(
-                    user_identifier="user@example.com",
-                    resource="https://graph.microsoft.com",
-                )
-                print(response.access_token)
+            OAuthProtocolError: If the response contains an OAuth error
+                (e.g. ``invalid_grant``, ``unauthorized_client``).
         """
-        request = TokenExchangeRequest(
-            subject_token=build_substitute_user_token(user_identifier),
-            subject_token_type=TokenType.SUBSTITUTE_USER,
-            resource=resource,
-            scope=scope,
-        )
+        if not user_identifier:
+            raise ValueError("user_identifier is required")
 
         endpoints = await self._get_current_endpoints()
 
@@ -779,6 +770,17 @@ class AsyncClient:
             user_agent=self.config.user_agent,
             custom_headers=self.config.custom_headers,
             timeout=timeout or self.config.timeout,
+        )
+
+        actor = await grant_client_credentials_async(ctx)
+
+        request = TokenExchangeRequest(
+            subject_token=build_substitute_user_token(user_identifier),
+            subject_token_type=TokenType.SUBSTITUTE_USER,
+            actor_token=actor.access_token,
+            actor_token_type=TokenType.ACCESS_TOKEN,
+            resource=resource,
+            scope=" ".join(scopes) if scopes else None,
         )
 
         return await exchange_token_async(request, ctx)
@@ -1301,23 +1303,24 @@ class Client:
         self,
         *,
         user_identifier: str,
-        resource: str,
-        scope: str | None = None,
+        resource: str | None = None,
+        scopes: list[str] | None = None,
         timeout: float | None = None,
     ) -> TokenResponse:
         """Impersonate a user to obtain a resource token.
 
-        Performs an RFC 8693 token exchange using a substitute-user subject token.
-        The calling application must authenticate via client credentials and the
-        user must have previously established a delegated grant for the resource.
+        Performs an RFC 8693 token exchange where the actor token is derived
+        from the client's application credential (via a client_credentials
+        grant) and the subject token is an unsigned substitute-user JWT
+        carrying the target user identifier.
 
-        This is a privileged operation controlled by policy. Impersonation is
-        forbidden by default; an administrator must explicitly allow it.
+        Impersonation is a privileged operation controlled server-side by
+        Keycard policy and is forbidden by default.
 
         Args:
-            user_identifier: Stable user identifier (e.g. email, oid).
-            resource: Target resource URI (e.g. "https://graph.microsoft.com").
-            scope: Optional scope string for the requested token.
+            user_identifier: Target user (becomes ``sub`` in the issued token).
+            resource: Optional target resource URI for the issued token.
+            scopes: Optional list of scopes requested for the issued token.
             timeout: Optional request timeout override.
 
         Returns:
@@ -1325,25 +1328,11 @@ class Client:
 
         Raises:
             OAuthHttpError: If the token endpoint returns an HTTP error.
-            OAuthProtocolError: If the response contains an OAuth error.
-
-        Example:
-            with Client(
-                "https://zone.keycard.cloud",
-                auth=BasicAuth("client_id", "client_secret"),
-            ) as client:
-                response = client.impersonate(
-                    user_identifier="user@example.com",
-                    resource="https://graph.microsoft.com",
-                )
-                print(response.access_token)
+            OAuthProtocolError: If the response contains an OAuth error
+                (e.g. ``invalid_grant``, ``unauthorized_client``).
         """
-        request = TokenExchangeRequest(
-            subject_token=build_substitute_user_token(user_identifier),
-            subject_token_type=TokenType.SUBSTITUTE_USER,
-            resource=resource,
-            scope=scope,
-        )
+        if not user_identifier:
+            raise ValueError("user_identifier is required")
 
         endpoints = self._get_current_endpoints()
 
@@ -1354,6 +1343,17 @@ class Client:
             user_agent=self.config.user_agent,
             custom_headers=self.config.custom_headers,
             timeout=timeout or self.config.timeout,
+        )
+
+        actor = grant_client_credentials(ctx)
+
+        request = TokenExchangeRequest(
+            subject_token=build_substitute_user_token(user_identifier),
+            subject_token_type=TokenType.SUBSTITUTE_USER,
+            actor_token=actor.access_token,
+            actor_token_type=TokenType.ACCESS_TOKEN,
+            resource=resource,
+            scope=" ".join(scopes) if scopes else None,
         )
 
         return exchange_token(request, ctx)

--- a/packages/oauth/src/keycardai/oauth/operations/_client_credentials.py
+++ b/packages/oauth/src/keycardai/oauth/operations/_client_credentials.py
@@ -1,0 +1,127 @@
+"""OAuth 2.0 Client Credentials grant (RFC 6749 Section 4.4).
+
+Used internally by impersonation to mint the actor access token derived from
+the client's application credential.
+"""
+
+import json
+from urllib.parse import urlencode
+
+from ..exceptions import OAuthHttpError, OAuthProtocolError
+from ..http._context import HTTPContext
+from ..http._wire import HttpRequest, HttpResponse
+from ..types.models import TokenResponse
+
+
+def build_client_credentials_http_request(
+    context: HTTPContext,
+    *,
+    scope: str | None = None,
+    resource: str | None = None,
+) -> HttpRequest:
+    payload: dict[str, str] = {"grant_type": "client_credentials"}
+    if scope:
+        payload["scope"] = scope
+    if resource:
+        payload["resource"] = resource
+
+    headers = {
+        "Accept": "application/json",
+        "Content-Type": "application/x-www-form-urlencoded",
+    }
+    if context.auth:
+        headers.update(dict(context.auth.apply_headers()))
+
+    return HttpRequest(
+        method="POST",
+        url=context.endpoint,
+        headers=headers,
+        body=urlencode(payload).encode("utf-8"),
+    )
+
+
+def parse_client_credentials_http_response(res: HttpResponse) -> TokenResponse:
+    if res.status >= 400:
+        full_body = res.body.decode("utf-8", "ignore")
+        try:
+            data = json.loads(full_body)
+            if isinstance(data, dict) and "error" in data:
+                raise OAuthProtocolError(
+                    error=data["error"],
+                    error_description=data.get("error_description"),
+                    error_uri=data.get("error_uri"),
+                    operation="POST /token (client_credentials)",
+                )
+        except (json.JSONDecodeError, ValueError):
+            pass
+        raise OAuthHttpError(
+            status_code=res.status,
+            response_body=full_body[:512],
+            headers=dict(res.headers),
+            operation="POST /token (client_credentials)",
+        )
+
+    try:
+        data = json.loads(res.body.decode("utf-8"))
+    except Exception as e:
+        raise OAuthProtocolError(
+            error="invalid_response",
+            error_description="Invalid JSON in client_credentials response",
+            operation="POST /token (client_credentials)",
+        ) from e
+
+    if isinstance(data, dict) and "error" in data:
+        raise OAuthProtocolError(
+            error=data["error"],
+            error_description=data.get("error_description"),
+            error_uri=data.get("error_uri"),
+            operation="POST /token (client_credentials)",
+        )
+
+    if not isinstance(data, dict) or "access_token" not in data:
+        raise OAuthProtocolError(
+            error="invalid_response",
+            error_description="Missing required 'access_token' in client_credentials response",
+            operation="POST /token (client_credentials)",
+        )
+
+    scope = data.get("scope")
+    if isinstance(scope, str):
+        scope = scope.split() if scope else None
+
+    return TokenResponse(
+        access_token=data["access_token"],
+        token_type=data.get("token_type", "Bearer"),
+        expires_in=data.get("expires_in"),
+        refresh_token=data.get("refresh_token"),
+        scope=scope,
+        issued_token_type=data.get("issued_token_type"),
+        raw=data,
+        headers=dict(res.headers),
+    )
+
+
+def grant_client_credentials(
+    context: HTTPContext,
+    *,
+    scope: str | None = None,
+    resource: str | None = None,
+) -> TokenResponse:
+    http_req = build_client_credentials_http_request(
+        context, scope=scope, resource=resource
+    )
+    http_res = context.transport.request_raw(http_req, timeout=context.timeout)
+    return parse_client_credentials_http_response(http_res)
+
+
+async def grant_client_credentials_async(
+    context: HTTPContext,
+    *,
+    scope: str | None = None,
+    resource: str | None = None,
+) -> TokenResponse:
+    http_req = build_client_credentials_http_request(
+        context, scope=scope, resource=resource
+    )
+    http_res = await context.transport.request_raw(http_req, timeout=context.timeout)
+    return parse_client_credentials_http_response(http_res)

--- a/packages/oauth/tests/keycardai/oauth/test_impersonate.py
+++ b/packages/oauth/tests/keycardai/oauth/test_impersonate.py
@@ -1,0 +1,192 @@
+"""Tests for Client.impersonate / AsyncClient.impersonate.
+
+Covers the unit-test table in specs/delegated-access/impersonation.md.
+"""
+
+import base64
+import json
+from unittest.mock import AsyncMock, Mock
+from urllib.parse import parse_qs
+
+import pytest
+
+from keycardai.oauth import AsyncClient, Client, ClientConfig
+from keycardai.oauth.exceptions import OAuthProtocolError
+from keycardai.oauth.http._wire import HttpResponse
+from keycardai.oauth.http.auth import BasicAuth
+from keycardai.oauth.types.oauth import TokenType
+
+CC_BODY = (
+    b'{"access_token": "actor-access-token", "token_type": "Bearer", '
+    b'"expires_in": 3600}'
+)
+EXCHANGE_BODY = (
+    b'{"access_token": "issued-token", "token_type": "Bearer", "expires_in": 3600, '
+    b'"scope": "read:mail"}'
+)
+
+
+def _ok(body: bytes) -> HttpResponse:
+    return HttpResponse(
+        status=200,
+        headers={"Content-Type": "application/json"},
+        body=body,
+    )
+
+
+def _err(status: int, code: str) -> HttpResponse:
+    return HttpResponse(
+        status=status,
+        headers={"Content-Type": "application/json"},
+        body=json.dumps({"error": code}).encode(),
+    )
+
+
+def _build_sync_client(transport: Mock) -> Client:
+    return Client(
+        base_url="https://zone.keycard.cloud",
+        auth=BasicAuth("app", "secret"),
+        transport=transport,
+        config=ClientConfig(
+            enable_metadata_discovery=False,
+            auto_register_client=False,
+        ),
+    )
+
+
+def _build_async_client(transport: AsyncMock) -> AsyncClient:
+    return AsyncClient(
+        base_url="https://zone.keycard.cloud",
+        auth=BasicAuth("app", "secret"),
+        transport=transport,
+        config=ClientConfig(
+            enable_metadata_discovery=False,
+            auto_register_client=False,
+        ),
+    )
+
+
+def _decode_payload(jwt: str) -> dict:
+    parts = jwt.split(".")
+    assert len(parts) == 3 and parts[2] == ""
+    pad = "=" * ((4 - len(parts[1]) % 4) % 4)
+    return json.loads(base64.urlsafe_b64decode(parts[1] + pad))
+
+
+class TestImpersonateSync:
+    """Spec table: rows 1–5, sync surface."""
+
+    def test_full_call_sends_substitute_user_token_and_actor(self):
+        transport = Mock()
+        transport.request_raw.side_effect = [_ok(CC_BODY), _ok(EXCHANGE_BODY)]
+
+        with _build_sync_client(transport) as client:
+            response = client.impersonate(
+                user_identifier="alice@example.com",
+                resource="https://graph.microsoft.com",
+                scopes=["read:mail"],
+            )
+
+        assert response.access_token == "issued-token"
+
+        # Two HTTP calls: client_credentials then token exchange
+        assert transport.request_raw.call_count == 2
+
+        cc_call, exchange_call = transport.request_raw.call_args_list
+        cc_form = parse_qs(cc_call.args[0].body.decode())
+        assert cc_form["grant_type"] == ["client_credentials"]
+
+        exchange_form = parse_qs(exchange_call.args[0].body.decode())
+        assert exchange_form["subject_token_type"] == [TokenType.SUBSTITUTE_USER.value]
+        assert exchange_form["actor_token"] == ["actor-access-token"]
+        assert exchange_form["actor_token_type"] == [TokenType.ACCESS_TOKEN.value]
+        assert exchange_form["resource"] == ["https://graph.microsoft.com"]
+        assert exchange_form["scope"] == ["read:mail"]
+
+        payload = _decode_payload(exchange_form["subject_token"][0])
+        assert payload == {"sub": "alice@example.com"}
+
+    def test_unknown_user_identifier_surfaces_invalid_grant(self):
+        transport = Mock()
+        transport.request_raw.side_effect = [_ok(CC_BODY), _err(400, "invalid_grant")]
+
+        with _build_sync_client(transport) as client:
+            with pytest.raises(OAuthProtocolError) as exc:
+                client.impersonate(user_identifier="ghost@example.com")
+        assert exc.value.error == "invalid_grant"
+
+    def test_unauthorized_client_surfaces_oauth_error(self):
+        transport = Mock()
+        transport.request_raw.side_effect = [
+            _ok(CC_BODY),
+            _err(400, "unauthorized_client"),
+        ]
+
+        with _build_sync_client(transport) as client:
+            with pytest.raises(OAuthProtocolError) as exc:
+                client.impersonate(user_identifier="alice@example.com")
+        assert exc.value.error == "unauthorized_client"
+
+    def test_resource_omitted_sends_no_resource_param(self):
+        transport = Mock()
+        transport.request_raw.side_effect = [_ok(CC_BODY), _ok(EXCHANGE_BODY)]
+
+        with _build_sync_client(transport) as client:
+            client.impersonate(user_identifier="alice@example.com")
+
+        exchange_form = parse_qs(transport.request_raw.call_args_list[1].args[0].body.decode())
+        assert "resource" not in exchange_form
+
+    def test_scopes_omitted_sends_no_scope_param(self):
+        transport = Mock()
+        transport.request_raw.side_effect = [_ok(CC_BODY), _ok(EXCHANGE_BODY)]
+
+        with _build_sync_client(transport) as client:
+            client.impersonate(
+                user_identifier="alice@example.com",
+                resource="https://api.example.com",
+            )
+
+        exchange_form = parse_qs(transport.request_raw.call_args_list[1].args[0].body.decode())
+        assert "scope" not in exchange_form
+
+    def test_empty_user_identifier_raises(self):
+        transport = Mock()
+        with _build_sync_client(transport) as client:
+            with pytest.raises(ValueError, match="user_identifier"):
+                client.impersonate(user_identifier="")
+        transport.request_raw.assert_not_called()
+
+
+class TestImpersonateAsync:
+    """Spec table mirrored for the async surface."""
+
+    @pytest.mark.asyncio
+    async def test_full_call(self):
+        transport = AsyncMock()
+        transport.request_raw.side_effect = [_ok(CC_BODY), _ok(EXCHANGE_BODY)]
+
+        async with _build_async_client(transport) as client:
+            response = await client.impersonate(
+                user_identifier="alice@example.com",
+                resource="https://graph.microsoft.com",
+                scopes=["read:mail", "read:calendar"],
+            )
+
+        assert response.access_token == "issued-token"
+        assert transport.request_raw.await_count == 2
+
+        exchange_form = parse_qs(transport.request_raw.await_args_list[1].args[0].body.decode())
+        assert exchange_form["subject_token_type"] == [TokenType.SUBSTITUTE_USER.value]
+        assert exchange_form["actor_token"] == ["actor-access-token"]
+        assert exchange_form["scope"] == ["read:mail read:calendar"]
+
+    @pytest.mark.asyncio
+    async def test_unknown_user_identifier(self):
+        transport = AsyncMock()
+        transport.request_raw.side_effect = [_ok(CC_BODY), _err(400, "invalid_grant")]
+
+        async with _build_async_client(transport) as client:
+            with pytest.raises(OAuthProtocolError) as exc:
+                await client.impersonate(user_identifier="ghost@example.com")
+        assert exc.value.error == "invalid_grant"


### PR DESCRIPTION
feat(oauth): implement user impersonation via substitute-user token exchange

Add Client.impersonate / AsyncClient.impersonate per specs/delegated-access/impersonation.md. Performs an RFC 8693 token exchange where the actor token is minted from the client's application credential via a client_credentials grant, and the subject token is an unsigned substitute-user JWT carrying the target user identifier.

- Add operations/_client_credentials.py (RFC 6749 §4.4 grant)
- Rework impersonate signature: user_identifier (req), resource (opt), scopes (opt list); wire actor_token/actor_token_type
- Add test_impersonate.py covering the spec unit-test table