### PR TITLE
feat(keycardai-mcp): infer multi-zone from a multi-zone ClientSecret

### DIFF
--- a/packages/mcp/src/keycardai/mcp/server/auth/provider.py
+++ b/packages/mcp/src/keycardai/mcp/server/auth/provider.py
@@ -66,7 +66,9 @@ class AuthProvider:
             application_credential=client_secret
         )
 
-        # Multi-zone support with zone-specific credentials
+        # Multi-zone support with zone-specific credentials.
+        # Passing a multi-zone ClientSecret enables multi-zone automatically;
+        # pass enable_multi_zone=True/False only to override.
         client_secret = ClientSecret({
             "zone1": ("client_id_1", "client_secret_1"),
             "zone2": ("client_id_2", "client_secret_2"),
@@ -75,7 +77,6 @@ class AuthProvider:
             zone_url="https://keycard.cloud",
             mcp_server_name="My MCP Server",
             application_credential=client_secret,
-            enable_multi_zone=True
         )
 
         @provider.grant("https://api.example.com")
@@ -93,7 +94,7 @@ class AuthProvider:
         required_scopes: list[str] | None = None,
         audience: str | dict[str, str] | None = None,
         mcp_server_url: AnyHttpUrl | str | None = None,
-        enable_multi_zone: bool = False,
+        enable_multi_zone: bool | None = None,
         base_url: str | None = None,
         client_factory: ClientFactory | None = None,
         enable_dynamic_client_registration: bool | None = None,
@@ -113,7 +114,9 @@ class AuthProvider:
                      - None: Skip audience validation (not recommended for production)
             mcp_server_url: Resource server URL (defaults to server URL)
             enable_multi_zone: Enable multi-zone support where zone_url is the top-level domain
-                              and zone_id is extracted from request context
+                              and zone_id is extracted from request context. When left unset
+                              (None), it is inferred from the credential: a multi-zone
+                              ClientSecret turns it on automatically. Pass True/False to override.
             base_url: Base URL for Keycard (default: https://keycard.cloud)
             client_factory: Client factory for creating OAuth clients. Defaults to DefaultClientFactory
             enable_dynamic_client_registration: Override automatic client registration behavior
@@ -128,6 +131,15 @@ class AuthProvider:
         mcp_server_url = mcp_server_url or os.getenv("MCP_SERVER_URL")
 
         self.base_url = base_url or "https://keycard.cloud"
+
+        # Infer multi-zone from a multi-zone ClientSecret unless explicitly set.
+        # Env-discovered credentials are always single-zone, so the passed
+        # argument is the only source that can imply multi-zone.
+        if enable_multi_zone is None:
+            enable_multi_zone = (
+                isinstance(application_credential, ClientSecret)
+                and application_credential.is_multi_zone
+            )
 
         if zone_url is None and not enable_multi_zone:
             if zone_id is None:

--- a/packages/mcp/tests/integration/test_auth_provider.py
+++ b/packages/mcp/tests/integration/test_auth_provider.py
@@ -72,6 +72,47 @@ class TestAuthProviderInitialization:
         assert isinstance(auth_provider.auth, BasicAuth)
         assert isinstance(auth_provider.application_credential, ClientSecret)
 
+    def test_multi_zone_inferred_from_credential(self, mock_client_factory):
+        """A multi-zone ClientSecret turns on multi-zone without an explicit flag."""
+        credential = ClientSecret({
+            "zone1": ("client_id_1", "client_secret_1"),
+            "zone2": ("client_id_2", "client_secret_2"),
+        })
+        auth_provider = AuthProvider(
+            zone_url="https://keycard.cloud",
+            mcp_server_url="http://localhost:8000",
+            application_credential=credential,
+            client_factory=mock_client_factory,
+        )
+
+        assert auth_provider.enable_multi_zone is True
+
+    def test_single_zone_credential_does_not_infer_multi_zone(self, mock_client_factory):
+        """A single-zone ClientSecret leaves multi-zone off."""
+        auth_provider = AuthProvider(
+            zone_id=mock_zone_id,
+            mcp_server_url="http://localhost:8000",
+            application_credential=ClientSecret(("client_id", "client_secret")),
+            client_factory=mock_client_factory,
+        )
+
+        assert auth_provider.enable_multi_zone is False
+
+    def test_explicit_enable_multi_zone_overrides_inference(self, mock_client_factory):
+        """An explicit enable_multi_zone value is respected over inference."""
+        credential = ClientSecret({
+            "zone1": ("client_id_1", "client_secret_1"),
+        })
+        auth_provider = AuthProvider(
+            zone_id=mock_zone_id,
+            mcp_server_url="http://localhost:8000",
+            application_credential=credential,
+            enable_multi_zone=False,
+            client_factory=mock_client_factory,
+        )
+
+        assert auth_provider.enable_multi_zone is False
+
     def test_auth_provider_init_with_required_scopes(self, mock_client_factory):
         """Test AuthProvider initialization with required scopes."""
         auth_provider = AuthProvider(

--- a/packages/oauth/src/keycardai/oauth/server/credentials.py
+++ b/packages/oauth/src/keycardai/oauth/server/credentials.py
@@ -111,6 +111,11 @@ class ClientSecret:
                 credentials_type=type(credentials).__name__
             )
 
+    @property
+    def is_multi_zone(self) -> bool:
+        """Whether this credential holds per-zone credentials."""
+        return isinstance(self.auth, MultiZoneBasicAuth)
+
     def get_http_client_auth(self) -> AuthStrategy:
         return self.auth
 


### PR DESCRIPTION
Closes consumption-parity gap with the TypeScript SDK for multi-zone setup.

## Problem
Python required `AuthProvider(application_credential=ClientSecret({...}), enable_multi_zone=True)` — you pass a multi-zone credential *and* must flip the flag. TS infers multi-zone from the credential alone, so passing a multi-zone `ClientSecret` is enough. Easy to pass the credential and forget the flag.

## Change
- `enable_multi_zone` now defaults to `None` and is **inferred from the credential**: a multi-zone `ClientSecret` turns it on automatically. Pass `True`/`False` to override.
- Adds `ClientSecret.is_multi_zone`.
- Env-discovered credentials are always single-zone, so the passed `application_credential` is the only source that can imply multi-zone — no constructor reordering needed.

After this, Python multi-zone setup matches TS: just pass a multi-zone `ClientSecret`.

```python
provider = AuthProvider(
    zone_url="https://keycard.cloud",
    application_credential=ClientSecret({"zone1": (...), "zone2": (...)}),
)  # multi-zone enabled automatically
```

## Tests
3 new tests (inferred-on, single-zone-off, explicit-override). `test_auth_provider.py` passes 9/9; ruff clean. Back-compat: explicit `enable_multi_zone=True/False` still honored.

Part of the SDK parity effort. Closes ECO-31.