### PR TITLE
fix(keycardai-oauth): enforce jwks_uri same-origin with issuer in TokenVerifier

### DIFF
--- a/packages/oauth/src/keycardai/oauth/server/exceptions.py
+++ b/packages/oauth/src/keycardai/oauth/server/exceptions.py
@@ -213,6 +213,19 @@ class JWKSDiscoveryError(OAuthServerError):
         super().__init__(message)
 
 
+class JWKSUriValidationError(OAuthServerError):
+    """The discovered jwks_uri is not same-origin with the issuer.
+
+    Guards against a tampered or misconfigured discovery document pointing key
+    resolution at an origin other than the issuer's.
+    """
+
+    def __init__(self, issuer: str, jwks_uri: str):
+        super().__init__(
+            f"Discovered jwks_uri '{jwks_uri}' is not same-origin with issuer '{issuer}'"
+        )
+
+
 class TokenValidationError(OAuthServerError):
     """Token validation failed due to invalid token format, signature, or claims."""
 

--- a/packages/oauth/src/keycardai/oauth/server/verifier.py
+++ b/packages/oauth/src/keycardai/oauth/server/verifier.py
@@ -21,6 +21,7 @@ from .client_factory import ClientFactory, DefaultClientFactory
 from .exceptions import (
     CacheError,
     JWKSDiscoveryError,
+    JWKSUriValidationError,
     UnsupportedAlgorithmError,
     VerifierConfigError,
 )
@@ -91,15 +92,28 @@ class TokenVerifier:
             client = self.client_factory.create_client(discovery_issuer)
             server_metadata = client.discover_server_metadata()
             discovered_uri = server_metadata.jwks_uri
-
-            if not discovered_uri:
-                raise JWKSDiscoveryError(discovery_issuer, zone_id)
-
-            self._discovered_jwks_uris[cache_key] = discovered_uri
-            return discovered_uri
-
         except Exception as e:
             raise JWKSDiscoveryError(discovery_issuer, zone_id, cause=e) from e
+
+        if not discovered_uri:
+            raise JWKSDiscoveryError(discovery_issuer, zone_id)
+
+        # Security: a discovered jwks_uri must share the issuer's origin, so a
+        # tampered discovery document cannot point key resolution elsewhere.
+        self._assert_same_origin(discovery_issuer, discovered_uri)
+
+        self._discovered_jwks_uris[cache_key] = discovered_uri
+        return discovered_uri
+
+    def _assert_same_origin(self, issuer: str, jwks_uri: str) -> None:
+        issuer_url = AnyHttpUrl(issuer)
+        jwks_url = AnyHttpUrl(jwks_uri)
+        if (
+            issuer_url.scheme != jwks_url.scheme
+            or issuer_url.host != jwks_url.host
+            or issuer_url.port != jwks_url.port
+        ):
+            raise JWKSUriValidationError(issuer, jwks_uri)
 
     def _create_zone_scoped_url(self, base_url: str, zone_id: str) -> str:
         """Create zone-scoped URL by prepending zone_id to the host."""

--- a/packages/oauth/tests/keycardai/oauth/server/test_verifier.py
+++ b/packages/oauth/tests/keycardai/oauth/server/test_verifier.py
@@ -9,10 +9,40 @@ from keycardai.oauth.exceptions import OAuthHttpError
 from keycardai.oauth.server._cache import JWKSKey
 from keycardai.oauth.server.exceptions import (
     JWKSDiscoveryError,
+    JWKSUriValidationError,
     VerifierConfigError,
 )
 from keycardai.oauth.server.verifier import AccessToken, TokenVerifier
 from keycardai.oauth.utils.jwt import JWTAccessToken
+
+
+class TestTokenVerifierJwksSameOrigin:
+    """A discovered jwks_uri must share the issuer's origin (security)."""
+
+    def _verifier_with_discovered_jwks(self, issuer: str, discovered_jwks_uri: str):
+        metadata = Mock()
+        metadata.jwks_uri = discovered_jwks_uri
+        client = Mock()
+        client.discover_server_metadata = Mock(return_value=metadata)
+        factory = Mock()
+        factory.create_client = Mock(return_value=client)
+        return TokenVerifier(issuer=issuer, client_factory=factory)
+
+    def test_cross_origin_discovered_jwks_uri_rejected(self):
+        verifier = self._verifier_with_discovered_jwks(
+            "https://example.com", "https://evil.example.net/.well-known/jwks.json"
+        )
+        with pytest.raises(JWKSUriValidationError):
+            verifier._discover_jwks_uri()
+
+    def test_same_origin_discovered_jwks_uri_accepted(self):
+        verifier = self._verifier_with_discovered_jwks(
+            "https://example.com", "https://example.com/.well-known/jwks.json"
+        )
+        assert (
+            verifier._discover_jwks_uri()
+            == "https://example.com/.well-known/jwks.json"
+        )
 
 
 class TestTokenVerifierVerifyToken:


### PR DESCRIPTION
Closes a security parity gap surfaced rewriting the jwks-caching spec (PHILOSOPHY.md #3: security semantics identical across SDKs).

## Problem
The TypeScript keyring asserts the discovered `jwks_uri` shares the issuer origin before fetching keys (`assertSameOrigin`). Python fetched whatever the discovery document returned, with no same-origin check — so a tampered/misconfigured discovery document could point key resolution at another origin.

## Change
- `TokenVerifier._discover_jwks_uri` now validates the **discovered** `jwks_uri` is same-origin (scheme + host + port) with the issuer before caching/using it.
- Adds typed `JWKSUriValidationError`, raised on mismatch.
- An explicit `jwks_uri=` (trusted caller config) is intentionally not subject to the check — only discovery-document-controlled URIs are.

## Tests
2 new tests (cross-origin rejected, same-origin accepted); full verifier suite passes (22). Ruff clean.

Part of the SDK parity effort. Companion to ECO-35 (JWKS caching behavioral parity). Closes ECO-34.