### PR TITLE
fix(keycardai-oauth): require kid in TokenVerifier (parity with TS verifier)

### DIFF
--- a/packages/oauth/src/keycardai/oauth/server/verifier.py
+++ b/packages/oauth/src/keycardai/oauth/server/verifier.py
@@ -22,6 +22,7 @@ from .exceptions import (
     CacheError,
     JWKSDiscoveryError,
     JWKSUriValidationError,
+    TokenValidationError,
     UnsupportedAlgorithmError,
     VerifierConfigError,
 )
@@ -137,6 +138,8 @@ class TokenVerifier:
         algorithm = header.get("alg")
         if algorithm not in self.allowed_algorithms:
             raise UnsupportedAlgorithmError(algorithm)
+        if not kid:
+            raise TokenValidationError("JWT missing key id (kid) header")
         return (kid, algorithm)
 
     def _get_zone_jwks_uri(self, jwks_uri: str, zone_id: str) -> str:

--- a/packages/oauth/tests/keycardai/oauth/server/test_verifier.py
+++ b/packages/oauth/tests/keycardai/oauth/server/test_verifier.py
@@ -10,6 +10,7 @@ from keycardai.oauth.server._cache import JWKSKey
 from keycardai.oauth.server.exceptions import (
     JWKSDiscoveryError,
     JWKSUriValidationError,
+    TokenValidationError,
     VerifierConfigError,
 )
 from keycardai.oauth.server.verifier import AccessToken, TokenVerifier
@@ -43,6 +44,33 @@ class TestTokenVerifierJwksSameOrigin:
             verifier._discover_jwks_uri()
             == "https://example.com/.well-known/jwks.json"
         )
+
+
+class TestTokenVerifierKidRequired:
+    """A token with no `kid` header is rejected (parity with the TypeScript verifier)."""
+
+    def test_missing_kid_rejected(self):
+        verifier = TokenVerifier(
+            issuer="https://example.com",
+            jwks_uri="https://example.com/.well-known/jwks.json",
+        )
+        with patch(
+            "keycardai.oauth.server.verifier.get_header",
+            return_value={"alg": "RS256"},
+        ):
+            with pytest.raises(TokenValidationError, match="kid"):
+                verifier._get_kid_and_algorithm("token")
+
+    def test_present_kid_accepted(self):
+        verifier = TokenVerifier(
+            issuer="https://example.com",
+            jwks_uri="https://example.com/.well-known/jwks.json",
+        )
+        with patch(
+            "keycardai.oauth.server.verifier.get_header",
+            return_value={"alg": "RS256", "kid": "abc"},
+        ):
+            assert verifier._get_kid_and_algorithm("token") == ("abc", "RS256")
 
 
 class TestTokenVerifierVerifyToken:


### PR DESCRIPTION
Closes the `kid`-requiredness divergence surfaced rewriting the jwks-caching spec.

## Problem
The TypeScript verifier rejects any token without a `kid` header (`InvalidTokenError`). Python silently fell back to the single JWKS key when `kid` was absent. "Optional in one SDK, required in the other" is exactly the kind of surprise PHILOSOPHY.md targets.

## Direction
Converge on **require kid in both** (the safer direction): Keycard always issues a `kid`, so this is no real-world loss, and it avoids loosening TS to accept tokens Keycard never issues.

## Change
- `TokenVerifier._get_kid_and_algorithm` now raises `TokenValidationError("JWT missing key id (kid) header")` when `kid` is absent, before key resolution.

## Tests
2 new (missing-kid rejected, present-kid accepted); verifier suite passes (22). Ruff clean.

Part of ECO-35 (JWKS caching behavioral parity).