### PR TITLE
Kamil/request scopes parameter

### DIFF
--- a/packages/fastmcp/src/keycardai/fastmcp/provider.py
+++ b/packages/fastmcp/src/keycardai/fastmcp/provider.py
@@ -603,7 +603,12 @@ class AuthProvider:
             resource_name=self.mcp_server_name,
         )
 
-    def grant(self, resources: str | list[str]):
+    def grant(
+        self,
+        resources: str | list[str],
+        *,
+        request_scopes: str | list[str] | dict[str, str | list[str]] | None = None,
+    ):
         """Decorator for automatic delegated token exchange.
 
         This decorator automates the OAuth token exchange process for accessing
@@ -619,6 +624,21 @@ class AuthProvider:
                       Can be a single string or list of strings.
                       (e.g., "https://api.example.com" or
                        ["https://api.example.com", "https://other-api.com"])
+            request_scopes: Optional OAuth scope(s) to request during the token
+                      exchange (RFC 8693 ``scope`` parameter), forwarded to Keycard
+                      so scope-gated delegation policies can match. Accepts:
+                      - ``str``: a single (space-delimited) scope string applied to
+                        every resource (e.g. ``"databricks:clusters:read"``).
+                      - ``list[str]``: joined with spaces and applied to every
+                        resource.
+                      - ``dict[str, str | list[str]]``: per-resource scopes keyed by
+                        resource URL; resources absent from the dict request no scope.
+                      Defaults to ``None`` (no scope sent).
+
+                      Note: ``request_scopes`` is the *outbound* scope requested
+                      during exchange. It is distinct from ``required_scopes`` on
+                      ``AuthProvider``, which the ``JWTVerifier`` enforces on the
+                      *inbound* caller token.
 
         Usage:
             ```python
@@ -642,6 +662,27 @@ class AuthProvider:
                 headers = {"Authorization": f"Bearer {token}"}
                 # Use headers to call external API
                 return f"Data for {user_id}"
+
+            # Request a scope for a single resource
+            @mcp.tool()
+            @auth_provider.grant(
+                "https://api.example.com",
+                request_scopes="databricks:clusters:read",
+            )
+            async def scoped_tool(ctx: Context):
+                ...
+
+            # Per-resource scopes when exchanging for multiple resources
+            @mcp.tool()
+            @auth_provider.grant(
+                ["https://api1.example.com", "https://api2.example.com"],
+                request_scopes={
+                    "https://api1.example.com": "read",
+                    "https://api2.example.com": ["read", "write"],
+                },
+            )
+            async def multi_tool(ctx: Context):
+                ...
             ```
 
         The decorated function must:
@@ -672,6 +713,19 @@ class AuthProvider:
                 if isinstance(value, Context):
                     return value
             return None
+
+        def _scope_for(resource: str) -> str | None:
+            """Resolve the RFC 8693 scope string to request for a resource."""
+            if request_scopes is None:
+                return None
+            value = (
+                request_scopes.get(resource)
+                if isinstance(request_scopes, dict)
+                else request_scopes
+            )
+            if value is None:
+                return None
+            return " ".join(value) if isinstance(value, list) else value
 
         async def _set_error(error: dict[str, str], resource: str | None, access_context: AccessContext, ctx: Context):
             """Helper to set error context and call function."""
@@ -760,6 +814,10 @@ class AuthProvider:
                                 resource=resource,
                                 subject_token_type="urn:ietf:params:oauth:token-type:access_token",
                             )
+
+                        _scope = _scope_for(resource)
+                        if _scope:
+                            _token_exchange_request.scope = _scope
 
                         _token_response = await self.client.exchange_token(_token_exchange_request)
 

--- a/packages/fastmcp/src/keycardai/fastmcp/provider.py
+++ b/packages/fastmcp/src/keycardai/fastmcp/provider.py
@@ -628,7 +628,7 @@ class AuthProvider:
                       exchange (RFC 8693 ``scope`` parameter), forwarded to Keycard
                       so scope-gated delegation policies can match. Accepts:
                       - ``str``: a single (space-delimited) scope string applied to
-                        every resource (e.g. ``"databricks:clusters:read"``).
+                        every resource (e.g. ``"read"``).
                       - ``list[str]``: joined with spaces and applied to every
                         resource.
                       - ``dict[str, str | list[str]]``: per-resource scopes keyed by
@@ -667,7 +667,7 @@ class AuthProvider:
             @mcp.tool()
             @auth_provider.grant(
                 "https://api.example.com",
-                request_scopes="databricks:clusters:read",
+                request_scopes="read",
             )
             async def scoped_tool(ctx: Context):
                 ...

--- a/packages/fastmcp/src/keycardai/fastmcp/provider.py
+++ b/packages/fastmcp/src/keycardai/fastmcp/provider.py
@@ -725,7 +725,8 @@ class AuthProvider:
             )
             if value is None:
                 return None
-            return " ".join(value) if isinstance(value, list) else value
+            scope = " ".join(value) if isinstance(value, list) else value
+            return scope or None
 
         async def _set_error(error: dict[str, str], resource: str | None, access_context: AccessContext, ctx: Context):
             """Helper to set error context and call function."""

--- a/packages/fastmcp/tests/integration/test_grant_decorator.py
+++ b/packages/fastmcp/tests/integration/test_grant_decorator.py
@@ -17,7 +17,7 @@ from keycardai.fastmcp import (
     ResourceAccessError,
 )
 from keycardai.mcp.server.exceptions import MissingContextError
-from keycardai.oauth.types.models import TokenResponse
+from keycardai.oauth.types.models import TokenExchangeRequest, TokenResponse
 
 
 async def check_access_context_for_errors(ctx: Context, resource: str = None):
@@ -218,6 +218,121 @@ class TestGrantDecoratorExecution:
 
         # Verify function executed successfully with both tokens
         assert result == "Hello user123, token1: token_api1_123, token2: token_api2_456"
+
+
+class TestGrantDecoratorRequestScopes:
+    """Test that the grant decorator forwards request_scopes into the exchange."""
+
+    def _capturing_provider(self, auth_provider_config, mock_client_factory):
+        """Build an AuthProvider whose exchange_token captures the request."""
+        auth_provider = AuthProvider(
+            **auth_provider_config,
+            client_factory=mock_client_factory,
+        )
+        captured: dict[str, TokenExchangeRequest] = {}
+
+        async def capturing_exchange(request: TokenExchangeRequest):
+            captured[request.resource] = request
+            return TokenResponse(
+                access_token="exchanged",
+                token_type="Bearer",
+                expires_in=3600,
+            )
+
+        mock_client = AsyncMock()
+        mock_client.exchange_token.side_effect = capturing_exchange
+        auth_provider.client = mock_client
+        return auth_provider, captured
+
+    @pytest.mark.asyncio
+    @patch("keycardai.fastmcp.provider.get_access_token")
+    async def test_grant_forwards_string_scope(
+        self, mock_get_token, auth_provider_config, mock_client_factory
+    ):
+        mock_get_token.return_value = AccessToken(
+            token="t", client_id="c", scopes=["s"]
+        )
+        auth_provider, captured = self._capturing_provider(
+            auth_provider_config, mock_client_factory
+        )
+
+        @auth_provider.grant(
+            "https://api.example.com", request_scopes="databricks:clusters:read"
+        )
+        async def tool(ctx: Context):
+            return "ok"
+
+        await tool(create_mock_context())
+
+        assert (
+            captured["https://api.example.com"].scope == "databricks:clusters:read"
+        )
+
+    @pytest.mark.asyncio
+    @patch("keycardai.fastmcp.provider.get_access_token")
+    async def test_grant_forwards_list_scope(
+        self, mock_get_token, auth_provider_config, mock_client_factory
+    ):
+        mock_get_token.return_value = AccessToken(
+            token="t", client_id="c", scopes=["s"]
+        )
+        auth_provider, captured = self._capturing_provider(
+            auth_provider_config, mock_client_factory
+        )
+
+        @auth_provider.grant(
+            "https://api.example.com", request_scopes=["read", "write"]
+        )
+        async def tool(ctx: Context):
+            return "ok"
+
+        await tool(create_mock_context())
+
+        assert captured["https://api.example.com"].scope == "read write"
+
+    @pytest.mark.asyncio
+    @patch("keycardai.fastmcp.provider.get_access_token")
+    async def test_grant_per_resource_scopes_dict(
+        self, mock_get_token, auth_provider_config, mock_client_factory
+    ):
+        mock_get_token.return_value = AccessToken(
+            token="t", client_id="c", scopes=["s"]
+        )
+        auth_provider, captured = self._capturing_provider(
+            auth_provider_config, mock_client_factory
+        )
+
+        @auth_provider.grant(
+            ["https://api1.example.com", "https://api2.example.com"],
+            request_scopes={"https://api1.example.com": "read"},
+        )
+        async def tool(ctx: Context):
+            return "ok"
+
+        await tool(create_mock_context())
+
+        assert captured["https://api1.example.com"].scope == "read"
+        assert captured["https://api2.example.com"].scope is None
+
+    @pytest.mark.asyncio
+    @patch("keycardai.fastmcp.provider.get_access_token")
+    async def test_grant_no_scope_default(
+        self, mock_get_token, auth_provider_config, mock_client_factory
+    ):
+        mock_get_token.return_value = AccessToken(
+            token="t", client_id="c", scopes=["s"]
+        )
+        auth_provider, captured = self._capturing_provider(
+            auth_provider_config, mock_client_factory
+        )
+
+        @auth_provider.grant("https://api.example.com")
+        async def tool(ctx: Context):
+            return "ok"
+
+        await tool(create_mock_context())
+
+        assert captured["https://api.example.com"].scope is None
 
 
 class TestAccessContext:

--- a/packages/fastmcp/tests/integration/test_grant_decorator.py
+++ b/packages/fastmcp/tests/integration/test_grant_decorator.py
@@ -257,7 +257,7 @@ class TestGrantDecoratorRequestScopes:
         )
 
         @auth_provider.grant(
-            "https://api.example.com", request_scopes="databricks:clusters:read"
+            "https://api.example.com", request_scopes="read"
         )
         async def tool(ctx: Context):
             return "ok"
@@ -265,7 +265,7 @@ class TestGrantDecoratorRequestScopes:
         await tool(create_mock_context())
 
         assert (
-            captured["https://api.example.com"].scope == "databricks:clusters:read"
+            captured["https://api.example.com"].scope == "read"
         )
 
     @pytest.mark.asyncio

--- a/packages/mcp/src/keycardai/mcp/server/auth/provider.py
+++ b/packages/mcp/src/keycardai/mcp/server/auth/provider.py
@@ -323,7 +323,13 @@ class AuthProvider:
             client_factory=self.client_factory,
         )
 
-    def grant(self, resources: str | list[str], user_identifier: Callable[..., str] | None = None):
+    def grant(
+        self,
+        resources: str | list[str],
+        user_identifier: Callable[..., str] | None = None,
+        *,
+        request_scopes: str | list[str] | dict[str, str | list[str]] | None = None,
+    ):
         """Decorator for automatic delegated token exchange.
 
         This decorator automates the OAuth token exchange process for accessing
@@ -337,6 +343,18 @@ class AuthProvider:
                       Can be a single string or list of strings.
                       (e.g., "https://api.example.com" or
                        ["https://api.example.com", "https://other-api.com"])
+            request_scopes: Optional OAuth scope(s) to request during the token
+                      exchange (RFC 8693 ``scope`` parameter), forwarded to Keycard
+                      so scope-gated delegation policies can match. Accepts:
+                      - ``str``: a single (space-delimited) scope string applied to
+                        every resource.
+                      - ``list[str]``: joined with spaces and applied to every
+                        resource.
+                      - ``dict[str, str | list[str]]``: per-resource scopes keyed by
+                        resource URL; resources absent from the dict request no scope.
+                      Defaults to ``None`` (no scope sent). This is the *outbound*
+                      scope requested during exchange, distinct from
+                      ``required_scopes`` enforced on the *inbound* caller token.
 
         Usage:
             ```python
@@ -425,6 +443,19 @@ class AuthProvider:
                 if isinstance(value, Context):
                     return value
             return None
+
+        def _scope_for(resource: str) -> str | None:
+            """Resolve the RFC 8693 scope string to request for a resource."""
+            if request_scopes is None:
+                return None
+            value = (
+                request_scopes.get(resource)
+                if isinstance(request_scopes, dict)
+                else request_scopes
+            )
+            if value is None:
+                return None
+            return " ".join(value) if isinstance(value, list) else value
 
         """
         Return the RequestContext parameter from the function arguments.
@@ -565,11 +596,13 @@ class AuthProvider:
                 _access_tokens = {}
                 for resource in _resource_list:
                     try:
+                        _scope = _scope_for(resource)
                         if _resolved_user_id is not None:
                             # Impersonation path: use substitute-user token exchange
                             _token_response = await _client.impersonate(
                                 user_identifier=_resolved_user_id,
                                 resource=resource,
+                                scope=_scope,
                             )
                         elif self.application_credential:
                             # Prepare token exchange request using application identity provider
@@ -579,6 +612,8 @@ class AuthProvider:
                                 resource=resource,
                                 auth_info=_keycardai_auth_info,
                             )
+                            if _scope:
+                                _token_exchange_request.scope = _scope
                             _token_response = await _client.exchange_token(_token_exchange_request)
                         else:
                             # Basic token exchange without client authentication
@@ -587,6 +622,8 @@ class AuthProvider:
                                 resource=resource,
                                 subject_token_type="urn:ietf:params:oauth:token-type:access_token",
                             )
+                            if _scope:
+                                _token_exchange_request.scope = _scope
                             _token_response = await _client.exchange_token(_token_exchange_request)
 
                         _access_tokens[resource] = _token_response

--- a/packages/mcp/src/keycardai/mcp/server/auth/provider.py
+++ b/packages/mcp/src/keycardai/mcp/server/auth/provider.py
@@ -455,7 +455,8 @@ class AuthProvider:
             )
             if value is None:
                 return None
-            return " ".join(value) if isinstance(value, list) else value
+            scope = " ".join(value) if isinstance(value, list) else value
+            return scope or None
 
         """
         Return the RequestContext parameter from the function arguments.

--- a/packages/mcp/tests/integration/test_grant_decorator.py
+++ b/packages/mcp/tests/integration/test_grant_decorator.py
@@ -250,7 +250,7 @@ class TestGrantDecoratorRequestScopes:
         auth_provider = AuthProvider(**auth_provider_config, client_factory=factory)
 
         @auth_provider.grant(
-            "https://api1.example.com", request_scopes="databricks:clusters:read"
+            "https://api1.example.com", request_scopes="read"
         )
         def tool(access_ctx: AccessContext, ctx: Context):
             return "ok"
@@ -259,7 +259,7 @@ class TestGrantDecoratorRequestScopes:
 
         assert (
             captured["exchange"]["https://api1.example.com"].scope
-            == "databricks:clusters:read"
+            == "read"
         )
 
     @pytest.mark.asyncio
@@ -315,7 +315,7 @@ class TestGrantDecoratorRequestScopes:
         @auth_provider.grant(
             "https://api1.example.com",
             user_identifier=lambda **kw: "user@example.com",
-            request_scopes="databricks:clusters:read",
+            request_scopes="read",
         )
         def tool(access_ctx: AccessContext, ctx: Context):
             return "ok"
@@ -326,7 +326,7 @@ class TestGrantDecoratorRequestScopes:
             {
                 "user_identifier": "user@example.com",
                 "resource": "https://api1.example.com",
-                "scope": "databricks:clusters:read",
+                "scope": "read",
             }
         ]
 

--- a/packages/mcp/tests/integration/test_grant_decorator.py
+++ b/packages/mcp/tests/integration/test_grant_decorator.py
@@ -17,7 +17,7 @@ from keycardai.mcp.server.auth import (
     MissingContextError,
     ResourceAccessError,
 )
-from keycardai.oauth.types.models import TokenResponse
+from keycardai.oauth.types.models import TokenExchangeRequest, TokenResponse
 
 
 def check_access_context_for_errors(access_ctx: AccessContext, resource: str = None):
@@ -213,6 +213,122 @@ class TestGrantDecoratorExecution:
 
         # Verify function executed successfully with both tokens
         assert result == "Hello user123, token1: token_api1_123, token2: token_api2_456"
+
+
+class TestGrantDecoratorRequestScopes:
+    """Test that the grant decorator forwards request_scopes into the exchange."""
+
+    def _capturing_factory(self):
+        """Build a client factory whose exchange_token/impersonate capture calls."""
+        captured: dict[str, object] = {"exchange": {}, "impersonate": []}
+
+        def capturing_exchange(request: TokenExchangeRequest | None = None, **kwargs):
+            captured["exchange"][request.resource] = request
+            return TokenResponse(
+                access_token="exchanged", token_type="Bearer", expires_in=3600
+            )
+
+        def capturing_impersonate(*, user_identifier, resource, scope=None, **kwargs):
+            captured["impersonate"].append(
+                {"user_identifier": user_identifier, "resource": resource, "scope": scope}
+            )
+            return TokenResponse(
+                access_token="impersonated", token_type="Bearer", expires_in=3600
+            )
+
+        mock_client = AsyncMock()
+        mock_client.exchange_token.side_effect = capturing_exchange
+        mock_client.impersonate.side_effect = capturing_impersonate
+
+        factory = Mock()
+        factory.create_async_client.return_value = mock_client
+        return factory, captured
+
+    @pytest.mark.asyncio
+    async def test_grant_forwards_string_scope(self, auth_provider_config):
+        factory, captured = self._capturing_factory()
+        auth_provider = AuthProvider(**auth_provider_config, client_factory=factory)
+
+        @auth_provider.grant(
+            "https://api1.example.com", request_scopes="databricks:clusters:read"
+        )
+        def tool(access_ctx: AccessContext, ctx: Context):
+            return "ok"
+
+        await tool(ctx=create_mock_context())
+
+        assert (
+            captured["exchange"]["https://api1.example.com"].scope
+            == "databricks:clusters:read"
+        )
+
+    @pytest.mark.asyncio
+    async def test_grant_forwards_list_scope(self, auth_provider_config):
+        factory, captured = self._capturing_factory()
+        auth_provider = AuthProvider(**auth_provider_config, client_factory=factory)
+
+        @auth_provider.grant(
+            "https://api1.example.com", request_scopes=["read", "write"]
+        )
+        def tool(access_ctx: AccessContext, ctx: Context):
+            return "ok"
+
+        await tool(ctx=create_mock_context())
+
+        assert captured["exchange"]["https://api1.example.com"].scope == "read write"
+
+    @pytest.mark.asyncio
+    async def test_grant_per_resource_scopes_dict(self, auth_provider_config):
+        factory, captured = self._capturing_factory()
+        auth_provider = AuthProvider(**auth_provider_config, client_factory=factory)
+
+        @auth_provider.grant(
+            ["https://api1.example.com", "https://api2.example.com"],
+            request_scopes={"https://api1.example.com": "read"},
+        )
+        def tool(access_ctx: AccessContext, ctx: Context):
+            return "ok"
+
+        await tool(ctx=create_mock_context())
+
+        assert captured["exchange"]["https://api1.example.com"].scope == "read"
+        assert captured["exchange"]["https://api2.example.com"].scope is None
+
+    @pytest.mark.asyncio
+    async def test_grant_no_scope_default(self, auth_provider_config):
+        factory, captured = self._capturing_factory()
+        auth_provider = AuthProvider(**auth_provider_config, client_factory=factory)
+
+        @auth_provider.grant("https://api1.example.com")
+        def tool(access_ctx: AccessContext, ctx: Context):
+            return "ok"
+
+        await tool(ctx=create_mock_context())
+
+        assert captured["exchange"]["https://api1.example.com"].scope is None
+
+    @pytest.mark.asyncio
+    async def test_grant_impersonation_scope(self, auth_provider_config):
+        factory, captured = self._capturing_factory()
+        auth_provider = AuthProvider(**auth_provider_config, client_factory=factory)
+
+        @auth_provider.grant(
+            "https://api1.example.com",
+            user_identifier=lambda **kw: "user@example.com",
+            request_scopes="databricks:clusters:read",
+        )
+        def tool(access_ctx: AccessContext, ctx: Context):
+            return "ok"
+
+        await tool(ctx=create_mock_context())
+
+        assert captured["impersonate"] == [
+            {
+                "user_identifier": "user@example.com",
+                "resource": "https://api1.example.com",
+                "scope": "databricks:clusters:read",
+            }
+        ]
 
 
 class TestAccessContext:

--- a/packages/oauth/src/keycardai/oauth/server/token_exchange.py
+++ b/packages/oauth/src/keycardai/oauth/server/token_exchange.py
@@ -66,7 +66,8 @@ async def exchange_tokens_for_resources(
         )
         if value is None:
             return None
-        return " ".join(value) if isinstance(value, list) else value
+        scope = " ".join(value) if isinstance(value, list) else value
+        return scope or None
 
     access_tokens: dict[str, TokenResponse] = {}
 

--- a/packages/oauth/src/keycardai/oauth/server/token_exchange.py
+++ b/packages/oauth/src/keycardai/oauth/server/token_exchange.py
@@ -21,6 +21,7 @@ async def exchange_tokens_for_resources(
     application_credential: ApplicationCredential | None = None,
     auth_info: dict[str, str] | None = None,
     user_identifier: str | None = None,
+    request_scopes: str | list[str] | dict[str, str | list[str]] | None = None,
 ) -> AccessContext:
     """Exchange a subject token for access tokens targeting one or more resources.
 
@@ -43,18 +44,40 @@ async def exchange_tokens_for_resources(
         application_credential: Optional credential provider for authenticated exchange.
         auth_info: Optional authentication context (zone_id, client_id, etc.).
         user_identifier: If set, use impersonation (substitute-user) exchange.
+        request_scopes: Optional OAuth scope(s) to request during the exchange
+            (RFC 8693 ``scope`` parameter). Accepts a ``str`` (applied to every
+            resource), a ``list[str]`` (space-joined, applied to every resource),
+            or a ``dict[str, str | list[str]]`` mapping resource URL to scope(s);
+            resources absent from the dict request no scope. This is the
+            *outbound* scope requested during exchange, distinct from any
+            *inbound* scope enforced on the caller token. Defaults to ``None``.
 
     Returns:
         The same AccessContext, populated with tokens and/or per-resource errors.
     """
+    def _scope_for(resource: str) -> str | None:
+        """Resolve the RFC 8693 scope string to request for a resource."""
+        if request_scopes is None:
+            return None
+        value = (
+            request_scopes.get(resource)
+            if isinstance(request_scopes, dict)
+            else request_scopes
+        )
+        if value is None:
+            return None
+        return " ".join(value) if isinstance(value, list) else value
+
     access_tokens: dict[str, TokenResponse] = {}
 
     for resource in resources:
         try:
+            scope = _scope_for(resource)
             if user_identifier is not None:
                 token_response = await client.impersonate(
                     user_identifier=user_identifier,
                     resource=resource,
+                    scope=scope,
                 )
             elif application_credential:
                 token_exchange_request = (
@@ -65,12 +88,15 @@ async def exchange_tokens_for_resources(
                         auth_info=auth_info,
                     )
                 )
+                if scope:
+                    token_exchange_request.scope = scope
                 token_response = await client.exchange_token(token_exchange_request)
             else:
                 token_exchange_request = TokenExchangeRequest(
                     subject_token=subject_token,
                     resource=resource,
                     subject_token_type="urn:ietf:params:oauth:token-type:access_token",
+                    scope=scope,
                 )
                 token_response = await client.exchange_token(token_exchange_request)
 

--- a/packages/oauth/tests/keycardai/oauth/server/test_token_exchange.py
+++ b/packages/oauth/tests/keycardai/oauth/server/test_token_exchange.py
@@ -1,0 +1,133 @@
+"""Unit tests for exchange_tokens_for_resources, focused on request_scopes."""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from keycardai.oauth.server.access_context import AccessContext
+from keycardai.oauth.server.token_exchange import exchange_tokens_for_resources
+from keycardai.oauth.types.models import TokenExchangeRequest, TokenResponse
+
+
+def _capturing_client():
+    """Return (client, captured) where captured records exchange/impersonate calls."""
+    captured: dict[str, object] = {"exchange": {}, "impersonate": []}
+
+    async def capturing_exchange(request: TokenExchangeRequest):
+        captured["exchange"][request.resource] = request
+        return TokenResponse(
+            access_token="exchanged", token_type="Bearer", expires_in=3600
+        )
+
+    async def capturing_impersonate(*, user_identifier, resource, scope=None, **kwargs):
+        captured["impersonate"].append(
+            {"user_identifier": user_identifier, "resource": resource, "scope": scope}
+        )
+        return TokenResponse(
+            access_token="impersonated", token_type="Bearer", expires_in=3600
+        )
+
+    client = AsyncMock()
+    client.exchange_token.side_effect = capturing_exchange
+    client.impersonate.side_effect = capturing_impersonate
+    return client, captured
+
+
+@pytest.mark.asyncio
+async def test_basic_exchange_forwards_string_scope():
+    client, captured = _capturing_client()
+    await exchange_tokens_for_resources(
+        client=client,
+        resources=["https://api.example.com"],
+        subject_token="subject",
+        access_context=AccessContext(),
+        request_scopes="databricks:clusters:read",
+    )
+    assert (
+        captured["exchange"]["https://api.example.com"].scope
+        == "databricks:clusters:read"
+    )
+
+
+@pytest.mark.asyncio
+async def test_basic_exchange_forwards_list_scope():
+    client, captured = _capturing_client()
+    await exchange_tokens_for_resources(
+        client=client,
+        resources=["https://api.example.com"],
+        subject_token="subject",
+        access_context=AccessContext(),
+        request_scopes=["read", "write"],
+    )
+    assert captured["exchange"]["https://api.example.com"].scope == "read write"
+
+
+@pytest.mark.asyncio
+async def test_per_resource_scopes_dict():
+    client, captured = _capturing_client()
+    await exchange_tokens_for_resources(
+        client=client,
+        resources=["https://api1.example.com", "https://api2.example.com"],
+        subject_token="subject",
+        access_context=AccessContext(),
+        request_scopes={"https://api1.example.com": "read"},
+    )
+    assert captured["exchange"]["https://api1.example.com"].scope == "read"
+    assert captured["exchange"]["https://api2.example.com"].scope is None
+
+
+@pytest.mark.asyncio
+async def test_no_scope_default():
+    client, captured = _capturing_client()
+    await exchange_tokens_for_resources(
+        client=client,
+        resources=["https://api.example.com"],
+        subject_token="subject",
+        access_context=AccessContext(),
+    )
+    assert captured["exchange"]["https://api.example.com"].scope is None
+
+
+@pytest.mark.asyncio
+async def test_impersonation_forwards_scope():
+    client, captured = _capturing_client()
+    await exchange_tokens_for_resources(
+        client=client,
+        resources=["https://api.example.com"],
+        subject_token="subject",
+        access_context=AccessContext(),
+        user_identifier="user@example.com",
+        request_scopes="databricks:clusters:read",
+    )
+    assert captured["impersonate"] == [
+        {
+            "user_identifier": "user@example.com",
+            "resource": "https://api.example.com",
+            "scope": "databricks:clusters:read",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_application_credential_sets_scope():
+    client, captured = _capturing_client()
+
+    class FakeCredential:
+        async def prepare_token_exchange_request(
+            self, *, client, subject_token, resource, auth_info=None
+        ):
+            return TokenExchangeRequest(
+                subject_token=subject_token,
+                resource=resource,
+                subject_token_type="urn:ietf:params:oauth:token-type:access_token",
+            )
+
+    await exchange_tokens_for_resources(
+        client=client,
+        resources=["https://api.example.com"],
+        subject_token="subject",
+        access_context=AccessContext(),
+        application_credential=FakeCredential(),
+        request_scopes="read",
+    )
+    assert captured["exchange"]["https://api.example.com"].scope == "read"

--- a/packages/oauth/tests/keycardai/oauth/server/test_token_exchange.py
+++ b/packages/oauth/tests/keycardai/oauth/server/test_token_exchange.py
@@ -89,6 +89,41 @@ async def test_no_scope_default():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("empty_scope", ["", []])
+async def test_basic_exchange_treats_empty_scope_as_absent(empty_scope):
+    client, captured = _capturing_client()
+    await exchange_tokens_for_resources(
+        client=client,
+        resources=["https://api.example.com"],
+        subject_token="subject",
+        access_context=AccessContext(),
+        request_scopes=empty_scope,
+    )
+    assert captured["exchange"]["https://api.example.com"].scope is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("empty_scope", ["", []])
+async def test_impersonation_treats_empty_scope_as_absent(empty_scope):
+    client, captured = _capturing_client()
+    await exchange_tokens_for_resources(
+        client=client,
+        resources=["https://api.example.com"],
+        subject_token="subject",
+        access_context=AccessContext(),
+        user_identifier="user@example.com",
+        request_scopes=empty_scope,
+    )
+    assert captured["impersonate"] == [
+        {
+            "user_identifier": "user@example.com",
+            "resource": "https://api.example.com",
+            "scope": None,
+        }
+    ]
+
+
+@pytest.mark.asyncio
 async def test_impersonation_forwards_scope():
     client, captured = _capturing_client()
     await exchange_tokens_for_resources(

--- a/packages/oauth/tests/keycardai/oauth/server/test_token_exchange.py
+++ b/packages/oauth/tests/keycardai/oauth/server/test_token_exchange.py
@@ -41,11 +41,11 @@ async def test_basic_exchange_forwards_string_scope():
         resources=["https://api.example.com"],
         subject_token="subject",
         access_context=AccessContext(),
-        request_scopes="databricks:clusters:read",
+        request_scopes="read",
     )
     assert (
         captured["exchange"]["https://api.example.com"].scope
-        == "databricks:clusters:read"
+        == "read"
     )
 
 
@@ -97,13 +97,13 @@ async def test_impersonation_forwards_scope():
         subject_token="subject",
         access_context=AccessContext(),
         user_identifier="user@example.com",
-        request_scopes="databricks:clusters:read",
+        request_scopes="read",
     )
     assert captured["impersonate"] == [
         {
             "user_identifier": "user@example.com",
             "resource": "https://api.example.com",
-            "scope": "databricks:clusters:read",
+            "scope": "read",
         }
     ]
 

--- a/packages/starlette/pyproject.toml
+++ b/packages/starlette/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.10"
 license = { text = "MIT" }
 authors = [{ name = "Keycard", email = "support@keycard.ai" }]
 dependencies = [
-    "keycardai-oauth>=0.9.0",
+    "keycardai-oauth>=0.13.0",
     "starlette>=0.47.3",
     "pydantic>=2.11.7",
     "httpx>=0.27.2",

--- a/packages/starlette/src/keycardai/starlette/authorization.py
+++ b/packages/starlette/src/keycardai/starlette/authorization.py
@@ -151,6 +151,8 @@ def grant(
     provider: AuthProvider,
     resources: str | list[str],
     user_identifier: Callable[..., str] | None = None,
+    *,
+    request_scopes: str | list[str] | dict[str, str | list[str]] | None = None,
 ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
     """Decorator factory for delegated OAuth 2.0 token exchange (RFC 8693).
 
@@ -171,6 +173,14 @@ def grant(
             keyword arguments, returns the user identifier to impersonate
             (RFC 8693 substitute-user exchange). When set, the exchange
             uses ``client.impersonate(...)``.
+        request_scopes: Optional OAuth scope(s) to request during the exchange
+            (RFC 8693 ``scope`` parameter). Accepts a ``str`` (applied to every
+            resource), a ``list[str]`` (space-joined, applied to every
+            resource), or a ``dict[str, str | list[str]]`` mapping resource URL
+            to scope(s); resources absent from the dict request no scope. This
+            is the *outbound* scope requested during exchange, distinct from
+            ``required_scopes`` enforced on the *inbound* caller token. Defaults
+            to ``None``.
 
     The decorated function must declare an ``AccessContext``-typed parameter;
     otherwise ``MissingAccessContextError`` is raised at decoration time.
@@ -266,6 +276,7 @@ def grant(
                 application_credential=provider.application_credential,
                 auth_info=auth_info,
                 user_identifier=resolved_user_id,
+                request_scopes=request_scopes,
             )
 
             return await _invoke(func, is_async, args, kwargs)


### PR DESCRIPTION
This PR introduces option to provide scopes requested as part of token exchange. This enables the caller to request specific scopes for the token, enabling finer grain authorization decisions during exchange. 