### PR TITLE
Kamil/fix protected router

### DIFF
--- a/packages/mcp/pyproject.toml
+++ b/packages/mcp/pyproject.toml
@@ -8,7 +8,7 @@ license = { text = "MIT" }
 authors = [{ name = "Keycard", email = "support@keycard.ai" }]
 dependencies = [
     "keycardai-oauth>=0.9.0",
-    "keycardai-starlette>=0.1.0",
+    "keycardai-starlette>=0.6.0",
     "mcp>=1.13.1",
     "pydantic>=2.11.7",
     "httpx>=0.27.2",

--- a/packages/mcp/src/keycardai/mcp/server/auth/provider.py
+++ b/packages/mcp/src/keycardai/mcp/server/auth/provider.py
@@ -483,9 +483,11 @@ class AuthProvider:
             return None
 
         """
-        The auth info object is set by the bearer token middleware during authorization.
-        This helper extracts the auth info from the request context from either the RequestContext or the Context parameter.
-        Required to support both FastMCP and lowlevel server implementations.
+        The authenticated user is set on the request by KeycardAuthBackend
+        (Starlette's AuthenticationMiddleware) during authorization. This helper
+        extracts the auth info from the request context from either the
+        RequestContext or the Context parameter. Required to support both FastMCP
+        and lowlevel server implementations.
         """
         def _extract_auth_info_from_context(
             *args, **kwargs
@@ -499,7 +501,20 @@ class AuthProvider:
             if _request_context is None:
                 return None
             try:
-                return _request_context.request.state.keycardai_auth_info
+                # KeycardAuthBackend populates request.user with a KeycardUser on
+                # success and an UnauthenticatedUser otherwise. Re-shape it into
+                # the dict the exchange paths below expect (mirroring the
+                # auth_info contract of the removed BearerAuthMiddleware).
+                _user = _request_context.request.user
+                if _user is None or not getattr(_user, "is_authenticated", False):
+                    return None
+                _resource_server_url = getattr(_user, "resource_server_url", None)
+                return {
+                    "access_token": getattr(_user, "access_token", None),
+                    "zone_id": getattr(_user, "zone_id", None),
+                    "resource_client_id": _resource_server_url,
+                    "resource_server_url": _resource_server_url,
+                }
             except Exception:
                 return None
 

--- a/packages/mcp/src/keycardai/mcp/server/routers/metadata.py
+++ b/packages/mcp/src/keycardai/mcp/server/routers/metadata.py
@@ -32,6 +32,11 @@ def protected_mcp_router(
     """Backward-compatible wrapper that accepts ``mcp_app`` kwarg.
 
     Delegates to ``protected_router(app=...)`` from keycardai-starlette.
+
+    The MCP streamable-HTTP app is an opaque ASGI sub-app with no per-route
+    ``@requires("authenticated")`` gate, so authentication is enforced at the
+    mount with ``require_authentication=True``: tokenless requests receive an
+    RFC 6750 challenge instead of reaching the dispatcher anonymously.
     """
     return protected_router(
         issuer=issuer,
@@ -39,6 +44,7 @@ def protected_mcp_router(
         verifier=verifier,
         enable_multi_zone=enable_multi_zone,
         jwks=jwks,
+        require_authentication=True,
     )
 
 

--- a/packages/mcp/tests/integration/e2e/test_authprovider_e2e.py
+++ b/packages/mcp/tests/integration/e2e/test_authprovider_e2e.py
@@ -26,12 +26,12 @@ def create_mock_context_with_auth_info(
     mock_context = Mock(spec=Context)
     mock_context.request_context = Mock()
     mock_context.request_context.request = Mock()
-    mock_context.request_context.request.state.keycardai_auth_info = {
-        "access_token": access_token,
-        "zone_id": zone_id,
-        "resource_client_id": resource_client_id,
-        "resource_server_url": resource_server_url,
-    }
+    mock_context.request_context.request.user = Mock(
+        is_authenticated=True,
+        access_token=access_token,
+        zone_id=zone_id,
+        resource_server_url=resource_server_url,
+    )
     return mock_context
 
 

--- a/packages/mcp/tests/integration/e2e/test_grant_decorator_e2e.py
+++ b/packages/mcp/tests/integration/e2e/test_grant_decorator_e2e.py
@@ -23,12 +23,12 @@ def create_mock_context_with_auth():
     mock_context = Mock(spec=Context)
     mock_context.request_context = Mock()
     mock_context.request_context.request = Mock()
-    mock_context.request_context.request.state.keycardai_auth_info = {
-        "access_token": "user_token",
-        "zone_id": "e2e-test",
-        "resource_client_id": "",
-        "resource_server_url": "http://localhost:8000/",
-    }
+    mock_context.request_context.request.user = Mock(
+        is_authenticated=True,
+        access_token="user_token",
+        zone_id="e2e-test",
+        resource_server_url="http://localhost:8000/",
+    )
     return mock_context
 
 
@@ -195,7 +195,7 @@ class TestGrantDecoratorE2E:
         mock_context = Mock(spec=Context)
         mock_context.request_context = Mock()
         mock_context.request_context.request = Mock()
-        mock_context.request_context.request.state = {}
+        mock_context.request_context.request.user = Mock(is_authenticated=False)
 
         result = await test_tool(ctx=mock_context)
 

--- a/packages/mcp/tests/integration/test_client_creation.py
+++ b/packages/mcp/tests/integration/test_client_creation.py
@@ -21,12 +21,12 @@ class TestClientCreation:
         mock_context = Mock(spec=Context)
         mock_context.request_context = Mock()
         mock_context.request_context.request = Mock()
-        mock_context.request_context.request.state.keycardai_auth_info = {
-            "access_token": "test_token",
-            "zone_id": zone_id,
-            "resource_client_id": "https://api.example.com",
-            "resource_server_url": "https://api.example.com"
-        }
+        mock_context.request_context.request.user = Mock(
+            is_authenticated=True,
+            access_token="test_token",
+            zone_id=zone_id,
+            resource_server_url="https://api.example.com",
+        )
         return mock_context
 
     @pytest.mark.asyncio

--- a/packages/mcp/tests/integration/test_eks_workload_identity.py
+++ b/packages/mcp/tests/integration/test_eks_workload_identity.py
@@ -31,12 +31,12 @@ class TestEKSWorkloadIdentity:
         mock_context = Mock(spec=Context)
         mock_context.request_context = Mock()
         mock_context.request_context.request = Mock()
-        mock_context.request_context.request.state.keycardai_auth_info = {
-            "access_token": "test_token",
-            "zone_id": zone_id,
-            "resource_client_id": "https://mcp.example.com",
-            "resource_server_url": "https://mcp.example.com"
-        }
+        mock_context.request_context.request.user = Mock(
+            is_authenticated=True,
+            access_token="test_token",
+            zone_id=zone_id,
+            resource_server_url="https://mcp.example.com",
+        )
         return mock_context
 
     @pytest.mark.asyncio

--- a/packages/mcp/tests/integration/test_grant_decorator.py
+++ b/packages/mcp/tests/integration/test_grant_decorator.py
@@ -47,24 +47,21 @@ def create_missing_auth_info_context():
     mock_context = Mock(spec=Context)
     mock_context.request_context = Mock()
     mock_context.request_context.request = Mock()
-    mock_context.request_context.request.state = {}
+    mock_context.request_context.request.user = Mock(is_authenticated=False)
     return mock_context
 
 def create_mock_context():
     """Helper function to create a mock Context with proper state management."""
     mock_context = Mock(spec=Context)
 
-    # Create a state storage for the mock context
-    context_state = {
-        "access_token": "test_token",
-        "zone_id": "test123",
-        "resource_client_id": "https://api.example.com",
-        "resource_server_url": "https://api.example.com"
-    }
-
     mock_context.request_context = Mock()
     mock_context.request_context.request = Mock()
-    mock_context.request_context.request.state.keycardai_auth_info = context_state
+    mock_context.request_context.request.user = Mock(
+        is_authenticated=True,
+        access_token="test_token",
+        zone_id="test123",
+        resource_server_url="https://api.example.com",
+    )
 
     return mock_context
 

--- a/packages/mcp/tests/integration/test_web_identity.py
+++ b/packages/mcp/tests/integration/test_web_identity.py
@@ -25,12 +25,12 @@ class TestWebIdentity:
         mock_context = Mock(spec=Context)
         mock_context.request_context = Mock()
         mock_context.request_context.request = Mock()
-        mock_context.request_context.request.state.keycardai_auth_info = {
-            "access_token": "test_token",
-            "zone_id": zone_id,
-            "resource_client_id": "https://mcp.example.com",
-            "resource_server_url": "https://mcp.example.com"
-        }
+        mock_context.request_context.request.user = Mock(
+            is_authenticated=True,
+            access_token="test_token",
+            zone_id=zone_id,
+            resource_server_url="https://mcp.example.com",
+        )
         return mock_context
 
     @pytest.mark.asyncio

--- a/packages/mcp/tests/keycardai/mcp/server/auth/test_provider.py
+++ b/packages/mcp/tests/keycardai/mcp/server/auth/test_provider.py
@@ -94,12 +94,12 @@ class TestGrantDecoratorParameterHandling:
         mock_context = Mock(spec=Context)
         mock_context.request_context = Mock()
         mock_context.request_context.request = Mock()
-        mock_context.request_context.request.state.keycardai_auth_info = {
-            "access_token": "test_token",
-            "zone_id": "test123",
-            "resource_client_id": "https://api.example.com",
-            "resource_server_url": "https://api.example.com"
-        }
+        mock_context.request_context.request.user = Mock(
+            is_authenticated=True,
+            access_token="test_token",
+            zone_id="test123",
+            resource_server_url="https://api.example.com",
+        )
         return mock_context
 
     def create_mock_context_without_auth(self):
@@ -107,7 +107,7 @@ class TestGrantDecoratorParameterHandling:
         mock_context = Mock(spec=Context)
         mock_context.request_context = Mock()
         mock_context.request_context.request = Mock()
-        mock_context.request_context.request.state = {}
+        mock_context.request_context.request.user = Mock(is_authenticated=False)
         return mock_context
 
     @pytest.mark.asyncio
@@ -279,19 +279,19 @@ class TestGrantDecoratorContextExtraction:
         """Helper to create a mock RequestContext with authentication info."""
         mock_request_context = Mock(spec=RequestContext)
         mock_request_context.request = Mock()
-        mock_request_context.request.state.keycardai_auth_info = {
-            "access_token": "test_token",
-            "zone_id": "test123",
-            "resource_client_id": "https://api.example.com",
-            "resource_server_url": "https://api.example.com"
-        }
+        mock_request_context.request.user = Mock(
+            is_authenticated=True,
+            access_token="test_token",
+            zone_id="test123",
+            resource_server_url="https://api.example.com",
+        )
         return mock_request_context
 
     def create_mock_request_context_without_auth(self):
         """Helper to create a mock RequestContext without authentication info."""
         mock_request_context = Mock(spec=RequestContext)
         mock_request_context.request = Mock()
-        mock_request_context.request.state = {}
+        mock_request_context.request.user = Mock(is_authenticated=False)
         return mock_request_context
 
     @pytest.mark.asyncio
@@ -373,12 +373,12 @@ class TestGrantDecoratorParameterInjection:
         mock_context = Mock(spec=Context)
         mock_context.request_context = Mock()
         mock_context.request_context.request = Mock()
-        mock_context.request_context.request.state.keycardai_auth_info = {
-            "access_token": "test_token",
-            "zone_id": "test123",
-            "resource_client_id": "https://api.example.com",
-            "resource_server_url": "https://api.example.com"
-        }
+        mock_context.request_context.request.user = Mock(
+            is_authenticated=True,
+            access_token="test_token",
+            zone_id="test123",
+            resource_server_url="https://api.example.com",
+        )
         return mock_context
 
     @pytest.mark.asyncio
@@ -521,12 +521,12 @@ class TestGrantDecoratorEdgeCases:
         mock_context = Mock(spec=Context)
         mock_context.request_context = Mock()
         mock_context.request_context.request = Mock()
-        mock_context.request_context.request.state.keycardai_auth_info = {
-            "access_token": "test_token",
-            "zone_id": "test123",
-            "resource_client_id": "https://api.example.com",
-            "resource_server_url": "https://api.example.com"
-        }
+        mock_context.request_context.request.user = Mock(
+            is_authenticated=True,
+            access_token="test_token",
+            zone_id="test123",
+            resource_server_url="https://api.example.com",
+        )
         return mock_context
 
     @pytest.mark.asyncio

--- a/packages/starlette/src/keycardai/starlette/routers/metadata.py
+++ b/packages/starlette/src/keycardai/starlette/routers/metadata.py
@@ -150,6 +150,7 @@ def protected_router(
     verifier: TokenVerifier,
     enable_multi_zone: bool = False,
     jwks: JsonWebKeySet | None = None,
+    require_authentication: bool = False,
 ) -> Sequence[Route]:
     """Create a protected router with OAuth metadata and bearer auth middleware.
 
@@ -163,6 +164,12 @@ def protected_router(
         verifier: Token verifier for bearer token validation.
         enable_multi_zone: When True, mount the app at ``/{zone_id:str}``.
         jwks: Optional JWKS to expose at ``/.well-known/jwks.json``.
+        require_authentication: When True, a request to the mounted app without
+            an ``Authorization`` header is rejected with an RFC 6750 challenge
+            instead of falling through anonymously. Use this for opaque ASGI
+            sub-apps (e.g. an MCP JSONRPC dispatcher) that have no per-route
+            ``@requires("authenticated")`` gate of their own. Defaults to False
+            to preserve the mixed-route behavior.
 
     Returns:
         Sequence of routes including metadata mount and protected app mount.
@@ -188,7 +195,9 @@ def protected_router(
 
     auth_middleware = Middleware(
         AuthenticationMiddleware,
-        backend=KeycardAuthBackend(verifier),
+        backend=KeycardAuthBackend(
+            verifier, require_authentication=require_authentication
+        ),
         on_error=keycard_on_error,
     )
 

--- a/packages/starlette/tests/keycardai/starlette/test_routers.py
+++ b/packages/starlette/tests/keycardai/starlette/test_routers.py
@@ -8,11 +8,14 @@ from unittest.mock import Mock, patch
 
 import pytest
 from starlette.applications import Starlette
+from starlette.responses import PlainTextResponse
 from starlette.testclient import TestClient
 
+from keycardai.oauth.server.verifier import TokenVerifier
 from keycardai.oauth.types import JsonWebKey, JsonWebKeySet
 from keycardai.starlette.routers.metadata import (
     auth_metadata_mount,
+    protected_router,
     well_known_metadata_mount,
 )
 
@@ -142,5 +145,44 @@ class TestAuthMetadataMount:
         app = Starlette(routes=[auth_metadata_mount(issuer=issuer)])
         response = TestClient(app).get(
             "/.well-known/oauth-protected-resource/any/path"
+        )
+        assert response.status_code == 200
+
+
+class TestProtectedRouterRequireAuthentication:
+    """Tokenless requests on an opaque mounted app must be challenged when
+    ``require_authentication=True`` (the contract used by protected_mcp_router).
+    """
+
+    async def _ok_app(self, scope, receive, send):
+        await PlainTextResponse("ok")(scope, receive, send)
+
+    def _client(self, issuer, *, require_authentication):
+        verifier = TokenVerifier(issuer=issuer)
+        app = Starlette(
+            routes=protected_router(
+                issuer=issuer,
+                app=self._ok_app,
+                verifier=verifier,
+                require_authentication=require_authentication,
+            )
+        )
+        return TestClient(app)
+
+    def test_tokenless_request_is_challenged_when_required(self, issuer):
+        response = self._client(issuer, require_authentication=True).get("/anything")
+        assert response.status_code == 401
+        assert "WWW-Authenticate" in response.headers
+        assert response.headers["WWW-Authenticate"].startswith("Bearer")
+        assert "resource_metadata=" in response.headers["WWW-Authenticate"]
+
+    def test_tokenless_request_passes_through_by_default(self, issuer):
+        response = self._client(issuer, require_authentication=False).get("/anything")
+        assert response.status_code == 200
+        assert response.text == "ok"
+
+    def test_oauth_metadata_remains_public_when_required(self, issuer):
+        response = self._client(issuer, require_authentication=True).get(
+            "/.well-known/oauth-protected-resource"
         )
         assert response.status_code == 200


### PR DESCRIPTION
This PR addresses a default allow anonymous access for the protected routes router in the MCP package. It exposes the configuration to require/disable authentication, with default set to require. This matches the default desired behaviour of the product. 

Additionally the grant decorator is updated to use correct user context value to obtain correct delegated auth tokens. 