### PR TITLE
feat(keycardai-oauth): converge JWKS caching to spec (discovery TTL, fetch timeout, inflight de-dup)

### DIFF
--- a/packages/oauth/src/keycardai/oauth/server/verifier.py
+++ b/packages/oauth/src/keycardai/oauth/server/verifier.py
@@ -5,11 +5,14 @@ and audience/scope validation. It replaces the MCP-dependent verifier with a
 framework-free implementation.
 """
 
+import asyncio
 import time
+import warnings
 from typing import Any
 
 from pydantic import AnyHttpUrl, BaseModel
 
+from keycardai.oauth.types.models import ClientConfig
 from keycardai.oauth.utils.jwt import (
     get_header,
     get_jwks_key,
@@ -52,45 +55,75 @@ class TokenVerifier:
         required_scopes: list[str] | None = None,
         jwks_uri: str | None = None,
         allowed_algorithms: list[str] = None,
-        cache_ttl: int = 300,
+        key_ttl: int = 300,
         enable_multi_zone: bool = False,
         audience: str | dict[str, str] | None = None,
         client_factory: ClientFactory | None = None,
+        *,
+        discovery_ttl: int = 3600,
+        fetch_timeout: float = 10.0,
+        cache_ttl: int | None = None,
     ):
         if not issuer:
             raise VerifierConfigError("Issuer is required for token verification")
         if allowed_algorithms is None:
             allowed_algorithms = ["RS256"]
+        if cache_ttl is not None:
+            warnings.warn(
+                "cache_ttl is deprecated; use key_ttl instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            key_ttl = cache_ttl
         self.issuer = issuer
         self.required_scopes = required_scopes or []
         self.jwks_uri = jwks_uri
         self.allowed_algorithms = allowed_algorithms
-        self.cache_ttl = cache_ttl
+        self.key_ttl = key_ttl
+        self.discovery_ttl = discovery_ttl
+        self.fetch_timeout = fetch_timeout
 
-        self._jwks_cache = JWKSCache(ttl=cache_ttl, max_size=10)
-        self._discovered_jwks_uri: str | None = None
-        self._discovered_jwks_uris: dict[str, str] = {}
+        self._jwks_cache = JWKSCache(ttl=key_ttl, max_size=10)
+        # Discovered jwks_uri per zone, with a discovery_ttl expiry:
+        # cache_key -> (jwks_uri, cached_at).
+        self._discovered_jwks_uris: dict[str, tuple[str, float]] = {}
+        # De-duplicate concurrent cold-cache key fetches (asyncio, one event loop).
+        self._key_inflight: dict[str, asyncio.Future] = {}
 
         self.enable_multi_zone = enable_multi_zone
         self.audience = audience
         self.client_factory = client_factory or DefaultClientFactory()
 
-    def _discover_jwks_uri(self, zone_id: str | None = None) -> str:
-        cache_key = f"{zone_id or 'default'}"
-        cached_uri = self._discovered_jwks_uris.get(cache_key)
-        if cached_uri is not None:
-            return cached_uri
+    @property
+    def cache_ttl(self) -> int:
+        """Deprecated alias for ``key_ttl``."""
+        return self.key_ttl
 
+    def _discover_jwks_uri(self, zone_id: str | None = None) -> str:
+        # An explicitly configured jwks_uri is static and bypasses discovery.
         if self.jwks_uri:
-            self._discovered_jwks_uris[cache_key] = self.jwks_uri
             return self.jwks_uri
+
+        cache_key = f"{zone_id or 'default'}"
+        cached = self._discovered_jwks_uris.get(cache_key)
+        if cached is not None:
+            cached_uri, cached_at = cached
+            if time.time() - cached_at < self.discovery_ttl:
+                return cached_uri
 
         discovery_issuer = self.issuer
         if self.enable_multi_zone and zone_id:
             discovery_issuer = self._create_zone_scoped_url(self.issuer, zone_id)
 
         try:
-            client = self.client_factory.create_client(discovery_issuer)
+            client = self.client_factory.create_client(
+                discovery_issuer,
+                config=ClientConfig(
+                    enable_metadata_discovery=True,
+                    auto_register_client=False,
+                    timeout=self.fetch_timeout,
+                ),
+            )
             server_metadata = client.discover_server_metadata()
             discovered_uri = server_metadata.jwks_uri
         except Exception as e:
@@ -103,7 +136,7 @@ class TokenVerifier:
         # tampered discovery document cannot point key resolution elsewhere.
         self._assert_same_origin(discovery_issuer, discovered_uri)
 
-        self._discovered_jwks_uris[cache_key] = discovered_uri
+        self._discovered_jwks_uris[cache_key] = (discovered_uri, time.time())
         return discovered_uri
 
     def _assert_same_origin(self, issuer: str, jwks_uri: str) -> None:
@@ -153,13 +186,36 @@ class TokenVerifier:
     async def _get_verification_key(
         self, token: str, zone_id: str | None = None
     ) -> JWKSKey:
-        """Get the verification key for the token with caching."""
+        """Get the verification key for the token, with caching and de-dup.
+
+        Concurrent cold-cache lookups for the same ``(zone, kid)`` share a
+        single in-flight resolution, so a burst of requests triggers one
+        discovery and one JWKS fetch rather than a thundering herd.
+        """
         kid, algorithm = self._get_kid_and_algorithm(token)
 
         cached_key = self._jwks_cache.get_key(kid)
         if cached_key is not None:
             return cached_key
 
+        inflight_key = f"{zone_id or 'default'}:{kid}"
+        existing = self._key_inflight.get(inflight_key)
+        if existing is not None:
+            return await existing
+
+        future = asyncio.ensure_future(
+            self._resolve_and_cache_key(kid, algorithm, zone_id)
+        )
+        self._key_inflight[inflight_key] = future
+        try:
+            return await future
+        finally:
+            self._key_inflight.pop(inflight_key, None)
+
+    async def _resolve_and_cache_key(
+        self, kid: str, algorithm: str, zone_id: str | None = None
+    ) -> JWKSKey:
+        """Discover the jwks_uri, fetch the key for ``kid``, and cache it."""
         if self.enable_multi_zone and zone_id:
             jwks_uri = self._discover_jwks_uri(zone_id)
         else:
@@ -167,7 +223,9 @@ class TokenVerifier:
             if zone_id:
                 jwks_uri = self._get_zone_jwks_uri(jwks_uri, zone_id)
 
-        verification_key = await get_jwks_key(kid, jwks_uri)
+        verification_key = await get_jwks_key(
+            kid, jwks_uri, timeout=self.fetch_timeout
+        )
 
         self._jwks_cache.set_key(kid, verification_key, algorithm)
         cached_key = self._jwks_cache.get_key(kid)

--- a/packages/oauth/src/keycardai/oauth/utils/jwt.py
+++ b/packages/oauth/src/keycardai/oauth/utils/jwt.py
@@ -513,12 +513,16 @@ async def get_verification_key(token: str, jwks_uri: str) -> str:
         raise ValueError(f"Failed to extract key ID from token: {e}") from e
 
 
-async def get_jwks_key(kid: str | None, jwks_uri: str) -> str:
+async def get_jwks_key(
+    kid: str | None, jwks_uri: str, timeout: float | None = None
+) -> str:
     """Fetch key from JWKS endpoint.
 
     Args:
         kid: Key ID from JWT header (optional)
         jwks_uri: JWKS endpoint URL
+        timeout: Timeout in seconds for the JWKS fetch. Falls back to the
+            transport default when not provided.
 
     Returns:
         Public key for verification (PEM format)
@@ -534,7 +538,7 @@ async def get_jwks_key(kid: str | None, jwks_uri: str) -> str:
 
         request = HttpRequest(method="GET", url=jwks_uri, headers={}, body=b"")
 
-        response = await transport.request_raw(request)
+        response = await transport.request_raw(request, timeout=timeout)
 
         if response.status != 200:
             raise ValueError(f"JWKS endpoint returned status {response.status}")

--- a/packages/oauth/tests/keycardai/oauth/server/test_verifier.py
+++ b/packages/oauth/tests/keycardai/oauth/server/test_verifier.py
@@ -1,5 +1,6 @@
 """Tests for TokenVerifier.verify_token method."""
 
+import asyncio
 import time
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -681,3 +682,100 @@ class TestTokenVerifierVerifyToken:
             assert result.token == "test.jwt.token"
             assert result.client_id == "test-client"
             mock_get_key.assert_called_once_with("test.jwt.token", "zone1")
+
+
+class TestTokenVerifierCacheKnobs:
+    """Cache knobs (key_ttl / discovery_ttl / fetch_timeout) and the cache_ttl alias."""
+
+    def test_default_knobs(self):
+        verifier = TokenVerifier(issuer="https://example.com")
+        assert verifier.key_ttl == 300
+        assert verifier.discovery_ttl == 3600
+        assert verifier.fetch_timeout == 10.0
+
+    def test_custom_knobs(self):
+        verifier = TokenVerifier(
+            issuer="https://example.com",
+            key_ttl=60,
+            discovery_ttl=120,
+            fetch_timeout=2.5,
+        )
+        assert verifier.key_ttl == 60
+        assert verifier.discovery_ttl == 120
+        assert verifier.fetch_timeout == 2.5
+
+    def test_cache_ttl_is_deprecated_alias_for_key_ttl(self):
+        with pytest.warns(DeprecationWarning, match="cache_ttl"):
+            verifier = TokenVerifier(issuer="https://example.com", cache_ttl=42)
+        assert verifier.key_ttl == 42
+        assert verifier.cache_ttl == 42
+
+
+class TestTokenVerifierDiscoveryTtl:
+    """The discovered jwks_uri is cached, then re-discovered after discovery_ttl."""
+
+    def _verifier(self, discovery_ttl: int):
+        metadata = Mock()
+        metadata.jwks_uri = "https://example.com/.well-known/jwks.json"
+        client = Mock()
+        client.discover_server_metadata = Mock(return_value=metadata)
+        factory = Mock()
+        factory.create_client = Mock(return_value=client)
+        verifier = TokenVerifier(
+            issuer="https://example.com",
+            client_factory=factory,
+            discovery_ttl=discovery_ttl,
+        )
+        return verifier, client
+
+    def test_cached_within_ttl(self):
+        verifier, client = self._verifier(discovery_ttl=3600)
+        with patch("keycardai.oauth.server.verifier.time.time", return_value=1000.0):
+            verifier._discover_jwks_uri()
+            verifier._discover_jwks_uri()
+        assert client.discover_server_metadata.call_count == 1
+
+    def test_rediscovers_after_ttl(self):
+        verifier, client = self._verifier(discovery_ttl=100)
+        with patch("keycardai.oauth.server.verifier.time.time") as mock_time:
+            mock_time.return_value = 1000.0
+            verifier._discover_jwks_uri()
+            mock_time.return_value = 1101.0
+            verifier._discover_jwks_uri()
+        assert client.discover_server_metadata.call_count == 2
+
+
+class TestTokenVerifierInflightDedup:
+    """Concurrent cold-cache lookups for the same kid share one JWKS fetch."""
+
+    @pytest.mark.asyncio
+    async def test_concurrent_fetches_share_one_fetch(self):
+        verifier = TokenVerifier(
+            issuer="https://example.com",
+            jwks_uri="https://example.com/.well-known/jwks.json",
+        )
+
+        call_count = 0
+
+        async def slow_get_jwks_key(kid, jwks_uri, timeout=None):
+            nonlocal call_count
+            call_count += 1
+            await asyncio.sleep(0.05)
+            return "mock-public-key"
+
+        with patch(
+            "keycardai.oauth.server.verifier.get_header",
+            return_value={"alg": "RS256", "kid": "abc"},
+        ), patch(
+            "keycardai.oauth.server.verifier.get_jwks_key",
+            side_effect=slow_get_jwks_key,
+        ):
+            results = await asyncio.gather(
+                verifier._get_verification_key("t1"),
+                verifier._get_verification_key("t2"),
+                verifier._get_verification_key("t3"),
+            )
+
+        assert call_count == 1
+        assert all(r.key == "mock-public-key" for r in results)
+        assert all(r.algorithm == "RS256" for r in results)


### PR DESCRIPTION
Converges the Python `TokenVerifier` JWKS caching to the canonical contract in `specs/jwt-jwks/jwks-caching.md` (ECO-35). Additive and backward-compatible.

## Changes
- **Discovery TTL.** The discovered `jwks_uri` is cached with a `discovery_ttl` (default 1h) and re-discovered after expiry, instead of being held for the verifier's lifetime.
- **Fetch timeout.** New `fetch_timeout` knob (default 10s) bounds the discovery and JWKS fetches. `get_jwks_key` gained an optional `timeout` argument.
- **Inflight de-duplication.** Concurrent cold-cache lookups for the same `(zone, kid)` share a single in-flight resolution, so a burst of requests triggers one discovery and one JWKS fetch rather than a thundering herd.
- **`key_ttl`.** The per-key TTL knob is now named `key_ttl` (the canonical name). `cache_ttl` remains as a deprecated keyword alias for one release and still works (emits a `DeprecationWarning`).

## Parity
Matches the TS `@keycardai/oauth` `JWKSOAuthKeyring` behavior at the verification surface (discovery TTL, per-fetch timeout, inflight de-dup). Canonical knob names follow the spec: `key_ttl` / `discovery_ttl` / `fetch_timeout`.

## Out of scope (decision-gated)
The remaining ECO-35 rows need a canonical choice, not a mechanical change, so they are intentionally deferred:
- key-cache eviction policy (`max_size=10` clear-all vs unbounded)
- error taxonomy (typed `JWKSDiscoveryError` etc. vs plain `Error`), which ties into ECO-32

## Note
For discovery, the verifier now passes a `ClientConfig(timeout=fetch_timeout)` to `client_factory.create_client`. This is transparent for the `DefaultClientFactory`; a custom factory receives the config per the factory protocol.

Tracked by ECO-35.

## Verification
- 253 oauth tests pass, including 6 new (knobs + `cache_ttl` alias, discovery-TTL re-expiry, inflight de-dup)
- starlette (40) and mcp (9) provider tests pass (TokenVerifier consumers)
- ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
