### PR TITLE
fix(keycardai-oauth): evict oldest JWKS key on overflow instead of clearing the cache

### DIFF
--- a/packages/oauth/src/keycardai/oauth/server/_cache.py
+++ b/packages/oauth/src/keycardai/oauth/server/_cache.py
@@ -18,12 +18,13 @@ class JWKSKey:
 class JWKSCache:
     """Thread-safe time-to-live cache for JWKS verification keys."""
 
-    def __init__(self, ttl: int = 300, max_size: int = 10):
+    def __init__(self, ttl: int = 300, max_size: int = 256):
         """Initialize the JWKS cache.
 
         Args:
             ttl: Time-to-live in seconds (default 300 = 5 minutes)
-            max_size: Maximum cache size before clearing (default 10)
+            max_size: Maximum number of cached keys; when full, the oldest
+                entry is evicted to make room (default 256)
         """
         self.ttl = ttl
         self.max_size = max_size
@@ -68,7 +69,13 @@ class JWKSCache:
 
         with self._lock:
             if len(self._cache) >= self.max_size and cache_key not in self._cache:
-                self._cache.clear()
+                # Evict the oldest entry (smallest timestamp) rather than
+                # clearing the whole cache, so a verifier serving many keys
+                # does not thrash.
+                oldest_key = min(
+                    self._cache, key=lambda k: self._cache[k].timestamp
+                )
+                del self._cache[oldest_key]
 
             self._cache[cache_key] = JWKSKey(key, current_time, algorithm)
 

--- a/packages/oauth/src/keycardai/oauth/server/verifier.py
+++ b/packages/oauth/src/keycardai/oauth/server/verifier.py
@@ -83,7 +83,7 @@ class TokenVerifier:
         self.discovery_ttl = discovery_ttl
         self.fetch_timeout = fetch_timeout
 
-        self._jwks_cache = JWKSCache(ttl=key_ttl, max_size=10)
+        self._jwks_cache = JWKSCache(ttl=key_ttl, max_size=256)
         # Discovered jwks_uri per zone, with a discovery_ttl expiry:
         # cache_key -> (jwks_uri, cached_at).
         self._discovered_jwks_uris: dict[str, tuple[str, float]] = {}

--- a/packages/oauth/tests/keycardai/oauth/server/test_cache.py
+++ b/packages/oauth/tests/keycardai/oauth/server/test_cache.py
@@ -15,7 +15,7 @@ class TestJWKSCache:
         # Default initialization
         cache = JWKSCache()
         assert cache.ttl == 300
-        assert cache.max_size == 10
+        assert cache.max_size == 256
         assert cache.size() == 0
 
         # Custom initialization
@@ -97,26 +97,28 @@ class TestJWKSCache:
         mock_time.return_value = 1301.0
         assert cache.get_key("key1") is None
 
-    def test_cache_size_limit(self):
-        """Test that cache clears when max size is reached."""
+    def test_cache_size_limit_evicts_oldest(self):
+        """When full, the cache evicts the oldest entry, not the whole cache."""
         cache = JWKSCache(max_size=3)
 
-        # Fill cache to max size
-        cache.set_key("key1", "value1", "RS256")
-        cache.set_key("key2", "value2", "ES256")
-        cache.set_key("key3", "value3", "PS256")
-        assert cache.size() == 3
+        with patch("keycardai.oauth.server._cache.time.time") as mock_time:
+            mock_time.return_value = 1000.0
+            cache.set_key("key1", "value1", "RS256")
+            mock_time.return_value = 1001.0
+            cache.set_key("key2", "value2", "ES256")
+            mock_time.return_value = 1002.0
+            cache.set_key("key3", "value3", "PS256")
+            assert cache.size() == 3
 
-        # Adding another item should clear the cache first
-        cache.set_key("key4", "value4", "RS256")
-        assert cache.size() == 1
-        cached_key = cache.get_key("key4")
-        assert cached_key is not None
-        assert cached_key.key == "value4"
-        # Previous keys should be gone
-        assert cache.get_key("key1") is None
-        assert cache.get_key("key2") is None
-        assert cache.get_key("key3") is None
+            # Adding a 4th key evicts the oldest (key1), not all keys.
+            mock_time.return_value = 1003.0
+            cache.set_key("key4", "value4", "RS256")
+
+            assert cache.size() == 3
+            assert cache.get_key("key1") is None
+            assert cache.get_key("key2") is not None
+            assert cache.get_key("key3") is not None
+            assert cache.get_key("key4") is not None
 
     def test_cache_size_limit_existing_key(self):
         """Test that updating existing key doesn't trigger size limit."""


### PR DESCRIPTION
Closes the key-cache eviction row of ECO-35 (jwks-caching), the mechanical follow-up to #143.

When the JWKS key cache hit `max_size` (10) it cleared **all** cached keys, so a verifier serving more than 10 distinct `kid`s would thrash (every 11th key wiped the other 10). This change:

- evicts the single **oldest** entry (smallest timestamp) on overflow instead of clearing the cache, and
- raises the bound to 256.

Matches the canonical contract agreed for ECO-35: the key cache is bounded with partial eviction, and the exact eviction order is implementation-defined. A matching bound for the TS `@keycardai/oauth` keyring is a companion change.

Tracked by ECO-35.

## Verification
- cache + verifier tests pass (incl. the updated eviction test asserting oldest-out, not clear-all)
- ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
