### PR TITLE
fix(keycardai-oauth): raise typed JWKS errors from get_jwks_key

### DIFF
--- a/packages/oauth/src/keycardai/oauth/__init__.py
+++ b/packages/oauth/src/keycardai/oauth/__init__.py
@@ -34,6 +34,9 @@ from .client import AsyncClient, Client
 from .exceptions import (
     AuthenticationError,
     ConfigError,
+    JWKSError,
+    JWKSFetchError,
+    JWKSKeyNotFoundError,
     NetworkError,
     OAuthError,
     OAuthHttpError,
@@ -75,6 +78,9 @@ __all__ = [
     "ConfigError",
     "AuthenticationError",
     "TokenExchangeError",
+    "JWKSError",
+    "JWKSFetchError",
+    "JWKSKeyNotFoundError",
     # === Data Models ===
     "TokenResponse",
     "ClientRegistrationResponse",

--- a/packages/oauth/src/keycardai/oauth/exceptions.py
+++ b/packages/oauth/src/keycardai/oauth/exceptions.py
@@ -164,3 +164,19 @@ class TokenExchangeError(OAuthProtocolError):
     ):
         super().__init__(error, error_description, error_uri, operation)
 
+
+class JWKSError(OAuthError):
+    """Base class for JWKS key-resolution failures (fetch and key lookup).
+
+    Raised by the low-level JWKS helper. Catch this to handle any JWKS
+    resolution failure, or a subclass for a single category.
+    """
+
+
+class JWKSFetchError(JWKSError):
+    """The JWKS endpoint could not be fetched or returned a non-2xx response."""
+
+
+class JWKSKeyNotFoundError(JWKSError):
+    """The requested key (`kid`) was not present in the fetched JWKS."""
+

--- a/packages/oauth/src/keycardai/oauth/utils/jwt.py
+++ b/packages/oauth/src/keycardai/oauth/utils/jwt.py
@@ -37,6 +37,7 @@ from typing import Any
 from authlib.jose import JsonWebKey, JsonWebToken
 from pydantic import BaseModel
 
+from ..exceptions import JWKSError, JWKSFetchError, JWKSKeyNotFoundError
 from ..http._transports import HttpxAsyncTransport
 from ..http._wire import HttpRequest
 from ..types.models import ClientConfig
@@ -528,7 +529,8 @@ async def get_jwks_key(
         Public key for verification (PEM format)
 
     Raises:
-        ValueError: If JWKS cannot be fetched or key not found
+        JWKSFetchError: If the JWKS endpoint cannot be reached or returns non-2xx.
+        JWKSKeyNotFoundError: If the requested key is not present in the JWKS.
     """
 
     try:
@@ -541,28 +543,30 @@ async def get_jwks_key(
         response = await transport.request_raw(request, timeout=timeout)
 
         if response.status != 200:
-            raise ValueError(f"JWKS endpoint returned status {response.status}")
+            raise JWKSFetchError(f"JWKS endpoint returned status {response.status}")
 
         jwks_data = json.loads(response.body.decode("utf-8"))
 
         keys = jwks_data.get("keys", [])
         if not keys:
-            raise ValueError("No keys found in JWKS")
+            raise JWKSKeyNotFoundError("No keys found in JWKS")
 
         if kid:
             for key_data in keys:
                 if key_data.get("kid") == kid:
                     jwk = JsonWebKey.import_key(key_data)
                     return jwk.get_public_key()  # type: ignore
-            raise ValueError(f"Key ID '{kid}' not found")
+            raise JWKSKeyNotFoundError(f"Key ID '{kid}' not found")
         else:
             if len(keys) == 1:
                 jwk = JsonWebKey.import_key(keys[0])
                 return jwk.get_public_key()  # type: ignore
             elif len(keys) > 1:
-                raise ValueError("Multiple keys in JWKS but no key ID (kid) in token")
+                raise JWKSKeyNotFoundError("Multiple keys in JWKS but no key ID (kid) in token")
             else:
-                raise ValueError("No keys found in JWKS")
+                raise JWKSKeyNotFoundError("No keys found in JWKS")
 
+    except JWKSError:
+        raise
     except Exception as e:
-        raise ValueError(f"Failed to fetch JWKS: {e}") from e
+        raise JWKSFetchError(f"Failed to fetch JWKS: {e}") from e

--- a/packages/oauth/tests/keycardai/oauth/utils/test_jwt.py
+++ b/packages/oauth/tests/keycardai/oauth/utils/test_jwt.py
@@ -10,6 +10,7 @@ from authlib.jose import JsonWebKey, JsonWebSignature
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 
+from keycardai.oauth.exceptions import JWKSFetchError, JWKSKeyNotFoundError
 from keycardai.oauth.utils.jwt import (
     JWTAccessToken,
     _decode_jwt_part,
@@ -483,7 +484,7 @@ class TestJWKSKeyFetching:
         mock_transport.request_raw.return_value = mock_response
         mock_transport_class.return_value = mock_transport
 
-        with pytest.raises(ValueError, match="Key ID 'key1' not found"):
+        with pytest.raises(JWKSKeyNotFoundError, match="Key ID 'key1' not found"):
             await get_jwks_key("key1", "https://example.com/.well-known/jwks.json")
 
     @pytest.mark.asyncio
@@ -500,7 +501,7 @@ class TestJWKSKeyFetching:
         mock_transport.request_raw.return_value = mock_response
         mock_transport_class.return_value = mock_transport
 
-        with pytest.raises(ValueError, match="JWKS endpoint returned status 404"):
+        with pytest.raises(JWKSFetchError, match="JWKS endpoint returned status 404"):
             await get_jwks_key("key1", "https://example.com/.well-known/jwks.json")
 
     @pytest.mark.asyncio
@@ -547,7 +548,7 @@ class TestJWKSKeyFetching:
         mock_transport.request_raw.return_value = mock_response
         mock_transport_class.return_value = mock_transport
 
-        with pytest.raises(ValueError, match="Multiple keys in JWKS but no key ID"):
+        with pytest.raises(JWKSKeyNotFoundError, match="Multiple keys in JWKS but no key ID"):
             await get_jwks_key(None, "https://example.com/.well-known/jwks.json")
 
     @pytest.mark.asyncio
@@ -565,7 +566,7 @@ class TestJWKSKeyFetching:
         mock_transport.request_raw.return_value = mock_response
         mock_transport_class.return_value = mock_transport
 
-        with pytest.raises(ValueError, match="No keys found in JWKS"):
+        with pytest.raises(JWKSKeyNotFoundError, match="No keys found in JWKS"):
             await get_jwks_key("key1", "https://example.com/.well-known/jwks.json")
 
 


### PR DESCRIPTION
Completes the error-model convergence: Python's low-level JWKS helper now raises typed, catchable exceptions instead of bare `ValueError`, matching the TS typed JWKS errors (typescript-sdk #67) and the canonical model (typed exceptions are the contract).

## Change
`get_jwks_key` (`utils/jwt.py`) raised `ValueError` for every failure, and its outer `except Exception` re-wrapped them all into a single generic `ValueError("Failed to fetch JWKS: …")`, flattening the failure type. Now:

- **`JWKSFetchError`**: endpoint unreachable, non-2xx, or transport failure.
- **`JWKSKeyNotFoundError`**: `kid` absent from the fetched JWKS (or an empty/ambiguous set).
- both under a **`JWKSError`** base in `keycardai.oauth.exceptions`, exported from the package root.

Typed errors propagate unchanged through the catch; only unexpected errors are wrapped as `JWKSFetchError`.

## Why the top-level exceptions module
The existing server-layer JWKS errors (`JWKSDiscoveryError`, `JWKSUriValidationError`) live in `server/exceptions.py`, which `utils/jwt.py` cannot import without a circular import (`server/__init__` -> verifier -> `utils/jwt`). These resolution-layer errors go in the leaf `oauth/exceptions.py`, which the utils layer imports cleanly. A future unification of both layers under one base is possible but not needed here.

## Note
`TokenVerifier.verify_token` still catches everything and returns `None` (lenient by design), so this changes no verifier behavior; it benefits direct `get_jwks_key` callers and aligns the taxonomy with TS.

## Verification
- 253 oauth tests pass (the 4 `get_jwks_key` assertions updated to the typed classes); verifier tests green
- import-cycle check passes; ruff clean

Part of the SDK parity effort (ECO-35 / ECO-32).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
