### PR TITLE
fix(keycardai-oauth): expose ResourceAccessError context attributes; fix get_errors annotation

### DIFF
--- a/packages/oauth/src/keycardai/oauth/server/access_context.py
+++ b/packages/oauth/src/keycardai/oauth/server/access_context.py
@@ -54,8 +54,8 @@ class AccessContext:
         """Check if there are any errors (global or resource-specific)."""
         return self.has_error() or len(self._resource_errors) > 0
 
-    def get_errors(self) -> dict[str, Any] | None:
-        """Get global errors if any."""
+    def get_errors(self) -> dict[str, Any]:
+        """Get a snapshot of all errors: the per-resource map and the global error."""
         return {"resources": self._resource_errors.copy(), "error": self._error}
 
     def get_error(self) -> dict[str, str] | None:

--- a/packages/oauth/src/keycardai/oauth/server/exceptions.py
+++ b/packages/oauth/src/keycardai/oauth/server/exceptions.py
@@ -273,6 +273,13 @@ class ResourceAccessError(OAuthServerError):
         available_resources: list[str] | None = None,
         error_details: dict | None = None,
     ):
+        # Exposed as instance attributes so handlers can inspect the error
+        # context directly without unpacking `details`.
+        self.resource = resource
+        self.error_type = error_type
+        self.available_resources = available_resources
+        self.error_details = error_details
+
         if message is None:
             resource_info = f"'{resource}'" if resource else "resource"
 

--- a/packages/oauth/tests/keycardai/oauth/server/test_access_context.py
+++ b/packages/oauth/tests/keycardai/oauth/server/test_access_context.py
@@ -80,3 +80,43 @@ def test_status_transitions():
 
     ctx.set_error({"message": "global boom"})
     assert ctx.get_status() == "error"
+
+
+def test_resource_access_error_exposes_context_attributes():
+    """ResourceAccessError exposes its context as direct attributes (TS parity)."""
+    ctx = AccessContext()
+    ctx.set_token("https://api.example.com", _token())
+
+    with pytest.raises(ResourceAccessError) as exc_info:
+        ctx.access("https://missing.example.com")
+
+    err = exc_info.value
+    assert err.resource == "https://missing.example.com"
+    assert err.error_type == "missing_token"
+    assert set(err.available_resources) == {"https://api.example.com"}
+    assert err.error_details is None
+
+
+def test_resource_access_error_attributes_for_resource_error():
+    ctx = AccessContext()
+    detail = {"message": "denied by AS", "code": "access_denied"}
+    ctx.set_resource_error("https://api.example.com", detail)
+
+    with pytest.raises(ResourceAccessError) as exc_info:
+        ctx.access("https://api.example.com")
+
+    err = exc_info.value
+    assert err.resource == "https://api.example.com"
+    assert err.error_type == "resource_error"
+    assert err.error_details == detail
+
+
+def test_get_errors_always_returns_a_dict():
+    ctx = AccessContext()
+    assert ctx.get_errors() == {"resources": {}, "error": None}
+
+    ctx.set_resource_error("https://api.example.com", {"message": "boom"})
+    ctx.set_error({"message": "global"})
+    snapshot = ctx.get_errors()
+    assert snapshot["error"] == {"message": "global"}
+    assert snapshot["resources"]["https://api.example.com"] == {"message": "boom"}


### PR DESCRIPTION
Closes the small access-context Python/TS parity gaps the divergence-verification pass surfaced. The spec claims Py/TS parity, but the code had two minor drifts.

## Changes
- **`ResourceAccessError` exposes its context as direct attributes.** It accepted `resource` / `error_type` / `available_resources` / `error_details` but only stored them nested in a `details` dict (with different keys, e.g. `requested_resource`). It now also sets them as direct instance attributes, matching the TS `ResourceAccessError` (which exposes `resource` / `errorType` / `availableResources` / `errorDetails` as readonly properties). A handler can now do `err.resource` / `err.error_type` instead of digging into `err.details`. The `details` dict is unchanged (back-compat).
- **`AccessContext.get_errors()` return annotation** corrected from `dict[str, Any] | None` to `dict[str, Any]` (it always returns a dict, never None).

Not changed: the error-payload representation (`dict` vs TS `ErrorDetail`); the spec deliberately marks that an intended language idiom.

## Verification
- 256 oauth tests pass (3 new: attribute exposure for missing-token and resource-error, plus the `get_errors` shape)
- ruff clean

Part of the SDK parity effort.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
