### PR TITLE
build(keycardai): use workspace sources for keycard deps in examples (uv 0.11.20+)

### DIFF
--- a/packages/a2a/examples/a2a_jsonrpc_usage/pyproject.toml
+++ b/packages/a2a/examples/a2a_jsonrpc_usage/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
 ]
 
 [tool.uv.sources]
-keycardai-a2a = { path = "../../", editable = true }
+keycardai-a2a = { workspace = true }
 
 [project.scripts]
 a2a-jsonrpc-usage = "main:run"

--- a/packages/a2a/examples/keycard_protected_server/pyproject.toml
+++ b/packages/a2a/examples/keycard_protected_server/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
 ]
 
 [tool.uv.sources]
-keycardai-a2a = { path = "../../", editable = true }
+keycardai-a2a = { workspace = true }
 
 [project.scripts]
 keycard-protected-server = "main:run"

--- a/packages/fastmcp/examples/delegated_access/pyproject.toml
+++ b/packages/fastmcp/examples/delegated_access/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
 ]
 
 [tool.uv.sources]
-keycardai-fastmcp = { path = "../../", editable = true }
+keycardai-fastmcp = { workspace = true }
 
 [project.scripts]
 delegated-access-server = "main:main"

--- a/packages/fastmcp/examples/hello_world_server/pyproject.toml
+++ b/packages/fastmcp/examples/hello_world_server/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
 ]
 
 [tool.uv.sources]
-keycardai-fastmcp = { path = "../../", editable = true }
+keycardai-fastmcp = { workspace = true }
 
 [project.scripts]
 hello-world-server = "main:main"

--- a/packages/mcp/examples/client_connection/pyproject.toml
+++ b/packages/mcp/examples/client_connection/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
 ]
 
 [tool.uv.sources]
-keycardai-mcp = { path = "../../", editable = true }
+keycardai-mcp = { workspace = true }
 
 [project.scripts]
 client-connection = "main:main"

--- a/packages/mcp/examples/delegated_access/pyproject.toml
+++ b/packages/mcp/examples/delegated_access/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
 ]
 
 [tool.uv.sources]
-keycardai-mcp = { path = "../../", editable = true }
+keycardai-mcp = { workspace = true }
 
 [project.scripts]
 delegated-access-server = "main:main"

--- a/packages/mcp/examples/hello_world_server/pyproject.toml
+++ b/packages/mcp/examples/hello_world_server/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
 ]
 
 [tool.uv.sources]
-keycardai-mcp = { path = "../../", editable = true }
+keycardai-mcp = { workspace = true }
 
 [project.scripts]
 hello-world-server = "main:main"

--- a/packages/oauth/examples/discover_server_metadata/pyproject.toml
+++ b/packages/oauth/examples/discover_server_metadata/pyproject.toml
@@ -9,4 +9,4 @@ dependencies = [
 ]
 
 [tool.uv.sources]
-keycardai-oauth = { path = "../../", editable = true }
+keycardai-oauth = { workspace = true }

--- a/packages/oauth/examples/dynamic_client_registration/pyproject.toml
+++ b/packages/oauth/examples/dynamic_client_registration/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
 ]
 
 [tool.uv.sources]
-keycardai-oauth = { path = "../../", editable = true }
+keycardai-oauth = { workspace = true }
 
 [project.scripts]
 dcr-demo = "main:main"

--- a/packages/oauth/examples/impersonation_token_exchange/pyproject.toml
+++ b/packages/oauth/examples/impersonation_token_exchange/pyproject.toml
@@ -9,4 +9,4 @@ dependencies = [
 ]
 
 [tool.uv.sources]
-keycardai-oauth = { path = "../../", editable = true }
+keycardai-oauth = { workspace = true }

--- a/packages/starlette/examples/protected_resource_server/pyproject.toml
+++ b/packages/starlette/examples/protected_resource_server/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
 ]
 
 [tool.uv.sources]
-keycardai-starlette = { path = "../../", editable = true }
+keycardai-starlette = { workspace = true }
 
 [project.scripts]
 protected-resource-server = "main:main"


### PR DESCRIPTION
CI's `lint-and-test` and `validate-commits` jobs started failing at the **dependency install** step (before ruff/tests), and it blocks every python-sdk PR plus main itself.

## Root cause (verified)
All workflows install uv via `astral-sh/setup-uv@v4` with **no version pin**, so every run grabs the latest uv. Today that's **uv 0.11.20**; recent green runs used an older uv. 0.11.20 started enforcing a rule it previously tolerated: a workspace member may not override a workspace source with a `{ path }`. The examples (globbed into the workspace via `packages/*/examples/*`) each redundantly declared `keycardai-<pkg> = { path = "../../", editable = true }`, while the root already declares `keycardai-<pkg> = { workspace = true }`. I reproduced the exact failure locally with uv 0.11.20.

## Fix
Per uv 0.11.20's own guidance, each example now declares its package via the workspace source: `keycardai-<pkg> = { workspace = true }` (11 example pyprojects, one line each). No uv pin — we stay on latest uv. `uv lock` shows **no lockfile changes** (path and workspace resolve to the same local package). Verified: `uv 0.11.20 lock` resolves all 261 packages cleanly.

Examples stay workspace members, so they keep resolving live local source for all keycard packages (good for monorepo dev). No test/lint coverage change (CI tests packages only; ruff is file-based).

## Heads-up: minimum uv version
`{ workspace = true }` is what 0.11.20 requires, but an **older uv (0.11.7) rejects it** ("not a workspace member") — the two versions are strict in opposite directions. Since we're standardizing on current uv this is the right form, but it does mean local dev needs a recent uv. (If we'd rather stay compatible with older uv, the alternative is excluding examples from the workspace — they'd then resolve transitive keycard deps from PyPI instead of local source.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
