### PR TITLE
build(keycardai): take examples out of the uv workspace

### DIFF
--- a/packages/a2a/examples/a2a_jsonrpc_usage/pyproject.toml
+++ b/packages/a2a/examples/a2a_jsonrpc_usage/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
 ]
 
 [tool.uv.sources]
-keycardai-a2a = { workspace = true }
+keycardai-a2a = { path = "../../", editable = true }
 
 [project.scripts]
 a2a-jsonrpc-usage = "main:run"

--- a/packages/a2a/examples/keycard_protected_server/pyproject.toml
+++ b/packages/a2a/examples/keycard_protected_server/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
 ]
 
 [tool.uv.sources]
-keycardai-a2a = { workspace = true }
+keycardai-a2a = { path = "../../", editable = true }
 
 [project.scripts]
 keycard-protected-server = "main:run"

--- a/packages/fastmcp/examples/delegated_access/pyproject.toml
+++ b/packages/fastmcp/examples/delegated_access/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
 ]
 
 [tool.uv.sources]
-keycardai-fastmcp = { workspace = true }
+keycardai-fastmcp = { path = "../../", editable = true }
 
 [project.scripts]
 delegated-access-server = "main:main"

--- a/packages/fastmcp/examples/hello_world_server/pyproject.toml
+++ b/packages/fastmcp/examples/hello_world_server/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
 ]
 
 [tool.uv.sources]
-keycardai-fastmcp = { workspace = true }
+keycardai-fastmcp = { path = "../../", editable = true }
 
 [project.scripts]
 hello-world-server = "main:main"

--- a/packages/mcp/examples/client_connection/pyproject.toml
+++ b/packages/mcp/examples/client_connection/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
 ]
 
 [tool.uv.sources]
-keycardai-mcp = { workspace = true }
+keycardai-mcp = { path = "../../", editable = true }
 
 [project.scripts]
 client-connection = "main:main"

--- a/packages/mcp/examples/delegated_access/pyproject.toml
+++ b/packages/mcp/examples/delegated_access/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
 ]
 
 [tool.uv.sources]
-keycardai-mcp = { workspace = true }
+keycardai-mcp = { path = "../../", editable = true }
 
 [project.scripts]
 delegated-access-server = "main:main"

--- a/packages/mcp/examples/hello_world_server/pyproject.toml
+++ b/packages/mcp/examples/hello_world_server/pyproject.toml
@@ -10,7 +10,7 @@ dependencies = [
 ]
 
 [tool.uv.sources]
-keycardai-mcp = { workspace = true }
+keycardai-mcp = { path = "../../", editable = true }
 
 [project.scripts]
 hello-world-server = "main:main"

--- a/packages/oauth/examples/discover_server_metadata/pyproject.toml
+++ b/packages/oauth/examples/discover_server_metadata/pyproject.toml
@@ -9,4 +9,4 @@ dependencies = [
 ]
 
 [tool.uv.sources]
-keycardai-oauth = { workspace = true }
+keycardai-oauth = { path = "../../", editable = true }

--- a/packages/oauth/examples/dynamic_client_registration/pyproject.toml
+++ b/packages/oauth/examples/dynamic_client_registration/pyproject.toml
@@ -8,7 +8,7 @@ dependencies = [
 ]
 
 [tool.uv.sources]
-keycardai-oauth = { workspace = true }
+keycardai-oauth = { path = "../../", editable = true }
 
 [project.scripts]
 dcr-demo = "main:main"

--- a/packages/oauth/examples/impersonation_token_exchange/pyproject.toml
+++ b/packages/oauth/examples/impersonation_token_exchange/pyproject.toml
@@ -9,4 +9,4 @@ dependencies = [
 ]
 
 [tool.uv.sources]
-keycardai-oauth = { workspace = true }
+keycardai-oauth = { path = "../../", editable = true }

--- a/packages/starlette/examples/protected_resource_server/pyproject.toml
+++ b/packages/starlette/examples/protected_resource_server/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
 ]
 
 [tool.uv.sources]
-keycardai-starlette = { workspace = true }
+keycardai-starlette = { path = "../../", editable = true }
 
 [project.scripts]
 protected-resource-server = "main:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,9 +58,10 @@ members = [
     "packages/mcp-fastmcp",
     "packages/fastmcp",
     "packages/a2a",
-    "packages/*/examples/*",
 ]
-exclude = []
+# Examples are standalone projects with their own lockfiles: each pins its parent
+# package via a path source and resolves the rest from the index.
+exclude = ["packages/*/examples/*"]
 
 [tool.uv.sources]
 # Workspace sources will be defined here as packages are added

--- a/scripts/changelog.py
+++ b/scripts/changelog.py
@@ -357,5 +357,5 @@ if __name__ == "__main__":
     try:
         main()
     except Exception as e:
-        print(f"❌ Error: {e}")
+        print(f"❌ Error: {e}", file=sys.stderr)
         sys.exit(1)

--- a/uv.lock
+++ b/uv.lock
@@ -11,16 +11,6 @@ resolution-markers = [
 
 [manifest]
 members = [
-    "a2a-jsonrpc-usage",
-    "client-connection-example",
-    "delegated-access-fastmcp-example",
-    "delegated-access-lowlevel-example",
-    "discover-server-metadata",
-    "dynamic-client-registration",
-    "hello-world-server",
-    "hello-world-server-lowlevel",
-    "impersonation-token-exchange",
-    "keycard-protected-server",
     "keycardai",
     "keycardai-a2a",
     "keycardai-fastmcp",
@@ -28,22 +18,6 @@ members = [
     "keycardai-mcp-fastmcp",
     "keycardai-oauth",
     "keycardai-starlette",
-    "protected-resource-server",
-]
-
-[[package]]
-name = "a2a-jsonrpc-usage"
-version = "0.1.0"
-source = { virtual = "packages/a2a/examples/a2a_jsonrpc_usage" }
-dependencies = [
-    { name = "httpx" },
-    { name = "keycardai-a2a" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "httpx", specifier = ">=0.27.2" },
-    { name = "keycardai-a2a", editable = "packages/a2a" },
 ]
 
 [[package]]
@@ -855,21 +829,6 @@ wheels = [
 ]
 
 [[package]]
-name = "client-connection-example"
-version = "0.1.0"
-source = { virtual = "packages/mcp/examples/client_connection" }
-dependencies = [
-    { name = "keycardai-mcp" },
-    { name = "uvicorn" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "keycardai-mcp", editable = "packages/mcp" },
-    { name = "uvicorn", specifier = ">=0.30.0" },
-]
-
-[[package]]
 name = "cohere"
 version = "5.21.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1174,40 +1133,6 @@ wheels = [
 ]
 
 [[package]]
-name = "delegated-access-fastmcp-example"
-version = "0.1.0"
-source = { virtual = "packages/fastmcp/examples/delegated_access" }
-dependencies = [
-    { name = "fastmcp" },
-    { name = "httpx" },
-    { name = "keycardai-fastmcp" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "fastmcp", specifier = ">=3.0.0" },
-    { name = "httpx", specifier = ">=0.27.0,<1.0.0" },
-    { name = "keycardai-fastmcp", editable = "packages/fastmcp" },
-]
-
-[[package]]
-name = "delegated-access-lowlevel-example"
-version = "0.1.0"
-source = { virtual = "packages/mcp/examples/delegated_access" }
-dependencies = [
-    { name = "httpx" },
-    { name = "keycardai-mcp" },
-    { name = "uvicorn" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "httpx", specifier = ">=0.27.0,<1.0.0" },
-    { name = "keycardai-mcp", editable = "packages/mcp" },
-    { name = "uvicorn", specifier = ">=0.30.0" },
-]
-
-[[package]]
 name = "deprecated"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1218,17 +1143,6 @@ sdist = { url = "https://files.pythonhosted.org/packages/49/85/12f0a49a7c4ffb705
 wheels = [
     { url = "https://files.pythonhosted.org/packages/84/d0/205d54408c08b13550c733c4b85429e7ead111c7f0014309637425520a9a/deprecated-1.3.1-py2.py3-none-any.whl", hash = "sha256:597bfef186b6f60181535a29fbe44865ce137a5079f295b479886c82729d5f3f", size = 11298, upload-time = "2025-10-30T08:19:00.758Z" },
 ]
-
-[[package]]
-name = "discover-server-metadata"
-version = "0.1.0"
-source = { virtual = "packages/oauth/examples/discover_server_metadata" }
-dependencies = [
-    { name = "keycardai-oauth" },
-]
-
-[package.metadata]
-requires-dist = [{ name = "keycardai-oauth", editable = "packages/oauth" }]
 
 [[package]]
 name = "distlib"
@@ -1283,17 +1197,6 @@ sdist = { url = "https://files.pythonhosted.org/packages/9d/a4/e44218c2b394e31a6
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b0/0d/9feae160378a3553fa9a339b0e9c1a048e147a4127210e286ef18b730f03/durationpy-0.10-py3-none-any.whl", hash = "sha256:3b41e1b601234296b4fb368338fdcd3e13e0b4fb5b67345948f4f2bf9868b286", size = 3922, upload-time = "2025-05-17T13:52:36.463Z" },
 ]
-
-[[package]]
-name = "dynamic-client-registration"
-version = "0.1.0"
-source = { virtual = "packages/oauth/examples/dynamic_client_registration" }
-dependencies = [
-    { name = "keycardai-oauth" },
-]
-
-[package.metadata]
-requires-dist = [{ name = "keycardai-oauth", editable = "packages/oauth" }]
 
 [[package]]
 name = "email-validator"
@@ -1399,6 +1302,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/94/6f/2adb571fda448d4afd2466e1cef2963fefdc6b37847da05249983e415f17/fastavro-1.12.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:bc44ba6289fb1f5ee318335958dde6ad6d742dcb4bb8930de843e9024c64b68c", size = 3281842, upload-time = "2026-04-24T14:37:20.833Z" },
     { url = "https://files.pythonhosted.org/packages/17/07/4bad2e96c4c6bae40253be2573cc09c1e5b9ccf821e1ff74e0d33b64bf90/fastavro-1.12.2-cp314-cp314-win_amd64.whl", hash = "sha256:a475418f71c5aed69899813ecccf392429c08c3a63df3030129db71760b0db8f", size = 450903, upload-time = "2026-04-24T14:37:23.059Z" },
     { url = "https://files.pythonhosted.org/packages/5b/b7/180f67ba9a46ba23a1ff6432f48d3087d4f2048579ecc262b00426cb1c63/fastavro-1.12.2-cp314-cp314-win_arm64.whl", hash = "sha256:daec9f9655a1d4636613c47d6d3343f6e039150d66cdce62543e20ca36612a8a", size = 391076, upload-time = "2026-04-24T14:37:24.756Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/8f/18f60329b627d2118a4a2b19e8741fbd807d60bf0470554e1bbfb7f1bca3/fastavro-1.12.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:57594b72cf663bbd0f3ad8a319a999fc3d7c71065a6799b2c1d1a6a137894c5b", size = 1055430, upload-time = "2026-05-09T21:53:14.364Z" },
     { url = "https://files.pythonhosted.org/packages/d2/ac/a1fa1fc29df0efc89d4946a743b09bdc9500591b5b92083eaf8e93664916/fastavro-1.12.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:74412132bbfb153cbf704517f2c89f7d3e170feb681b13bceace690f66f8d5fa", size = 3503075, upload-time = "2026-04-24T14:37:26.826Z" },
     { url = "https://files.pythonhosted.org/packages/82/bf/4f669e10b6bc38a731ee3400aed1a1e2d0a3e3cf411e72f6b320d3af0eaf/fastavro-1.12.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e367a84c9133018e0a3bc822abe78d7f1f9a6092991a0ec409468cf4ef260282", size = 3410900, upload-time = "2026-04-24T14:37:29.233Z" },
     { url = "https://files.pythonhosted.org/packages/10/39/ecb19fdae4158a7730b5963fbf1b6d38d74678392d73083be518642af0c1/fastavro-1.12.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:044fafca0853e9ae14009de7763ac9e8e8f8b96f8a4e90bd58b695443266a370", size = 3335637, upload-time = "2026-04-24T14:37:31.472Z" },
@@ -1788,36 +1692,6 @@ wheels = [
 ]
 
 [[package]]
-name = "hello-world-server"
-version = "0.1.0"
-source = { virtual = "packages/fastmcp/examples/hello_world_server" }
-dependencies = [
-    { name = "fastmcp" },
-    { name = "keycardai-fastmcp" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "fastmcp", specifier = ">=3.0.0" },
-    { name = "keycardai-fastmcp", editable = "packages/fastmcp" },
-]
-
-[[package]]
-name = "hello-world-server-lowlevel"
-version = "0.1.0"
-source = { virtual = "packages/mcp/examples/hello_world_server" }
-dependencies = [
-    { name = "keycardai-mcp" },
-    { name = "uvicorn" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "keycardai-mcp", editable = "packages/mcp" },
-    { name = "uvicorn", specifier = ">=0.30.0" },
-]
-
-[[package]]
 name = "hf-xet"
 version = "1.4.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1965,21 +1839,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ce/cc/762dfb036166873f0059f3b7de4565e1b5bc3d6f28a414c13da27e442f99/idna-3.13.tar.gz", hash = "sha256:585ea8fe5d69b9181ec1afba340451fba6ba764af97026f92a91d4eef164a242", size = 194210, upload-time = "2026-04-22T16:42:42.314Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5d/13/ad7d7ca3808a898b4612b6fe93cde56b53f3034dcde235acb1f0e1df24c6/idna-3.13-py3-none-any.whl", hash = "sha256:892ea0cde124a99ce773decba204c5552b69c3c67ffd5f232eb7696135bc8bb3", size = 68629, upload-time = "2026-04-22T16:42:40.909Z" },
-]
-
-[[package]]
-name = "impersonation-token-exchange"
-version = "0.1.0"
-source = { virtual = "packages/oauth/examples/impersonation_token_exchange" }
-dependencies = [
-    { name = "keycardai-oauth" },
-    { name = "python-dotenv" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "keycardai-oauth", editable = "packages/oauth" },
-    { name = "python-dotenv", specifier = ">=1.0.0" },
 ]
 
 [[package]]
@@ -2323,21 +2182,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
-]
-
-[[package]]
-name = "keycard-protected-server"
-version = "0.1.0"
-source = { virtual = "packages/a2a/examples/keycard_protected_server" }
-dependencies = [
-    { name = "keycardai-a2a" },
-    { name = "uvicorn", extra = ["standard"] },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "keycardai-a2a", editable = "packages/a2a" },
-    { name = "uvicorn", extras = ["standard"], specifier = ">=0.32.0" },
 ]
 
 [[package]]
@@ -4310,27 +4154,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/ef/3c6ecf8b317aa982f309835e8f96987466123c6e596646d4e6a1dfcd080f/propcache-0.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:990f6b3e2a27d683cb7602ed6c86f15ee6b43b1194736f9baaeb93d0016633b1", size = 46259, upload-time = "2025-10-08T19:48:34.226Z" },
     { url = "https://files.pythonhosted.org/packages/c4/2d/346e946d4951f37eca1e4f55be0f0174c52cd70720f84029b02f296f4a38/propcache-0.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:ecef2343af4cc68e05131e45024ba34f6095821988a9d0a02aa7c73fcc448aa9", size = 40428, upload-time = "2025-10-08T19:48:35.441Z" },
     { url = "https://files.pythonhosted.org/packages/5b/5a/bc7b4a4ef808fa59a816c17b20c4bef6884daebbdf627ff2a161da67da19/propcache-0.4.1-py3-none-any.whl", hash = "sha256:af2a6052aeb6cf17d3e46ee169099044fd8224cbaf75c76a2ef596e8163e2237", size = 13305, upload-time = "2025-10-08T19:49:00.792Z" },
-]
-
-[[package]]
-name = "protected-resource-server"
-version = "0.1.0"
-source = { virtual = "packages/starlette/examples/protected_resource_server" }
-dependencies = [
-    { name = "fastapi" },
-    { name = "httpx" },
-    { name = "keycardai-starlette" },
-    { name = "python-dotenv" },
-    { name = "uvicorn" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "fastapi", specifier = ">=0.116.0" },
-    { name = "httpx", specifier = ">=0.27.2" },
-    { name = "keycardai-starlette", editable = "packages/starlette" },
-    { name = "python-dotenv", specifier = ">=1.0.0" },
-    { name = "uvicorn", specifier = ">=0.30.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why
#150 switched the example `[tool.uv.sources]` from `{ path }` to `{ workspace = true }`, which unblocked the PR jobs (`uv sync`, `cz check`). But the **Merge to Main** `detect-changes` job kept failing. It runs `uv run cz changelog --dry-run` at the workspace root, which makes uv generate package metadata for every member, including the 11 examples. uv 0.11.20 (released 2026-06-10, pulled in by the unpinned `setup-uv@v4`) fails that metadata generation on the Linux runner, even though plain `uv sync --all-packages` and the macOS / PR path succeed.

The examples were never meant to be workspace members: they ship their own `uv.lock` files and each only pins its parent package. Globbing them in via `packages/*/examples/*` is what drags them into every root resolution.

## Change
- Drop `packages/*/examples/*` from `[tool.uv.workspace].members` and add it to `exclude`.
- Restore the examples' parent-package `{ path = "../../", editable = true }` sources (valid for standalone projects).
- Regenerate the root `uv.lock` (the 11 example virtual packages drop out, -179 lines).
- Route `scripts/changelog.py` error output to stderr. It was going to stdout, where `PACKAGES=$(just detect-changes)` swallowed it under `bash -e`, which is why the failing job showed no error in the CI log.

## Verification
- Locally on uv 0.11.20: `uv sync --all-extras --all-packages`, `uv run cz changelog`, and `python scripts/changelog.py changes` all pass; examples no longer appear in the lock or any root resolution.
- I could not produce a faithful Linux repro (Docker daemon would not stay up in my env). The fix removes example resolution by construction, so the Linux metadata-gen failure cannot recur. `detect-changes` only runs on push to main, so the definitive check is the Merge to Main run after this lands; the stderr change makes any residual failure visible there.

## Tradeoff
Examples now resolve their transitive keycard deps from the index instead of live local source (the parent package stays local/editable). Fine for demos; flagged for awareness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
