### PR TITLE
feat(keycardai-oauth)!: raise typed InvalidTokenError and enforce issuer allowlist before key resolution

### DIFF
--- a/packages/oauth/src/keycardai/oauth/__init__.py
+++ b/packages/oauth/src/keycardai/oauth/__init__.py
@@ -34,6 +34,7 @@ from .client import AsyncClient, Client
 from .exceptions import (
     AuthenticationError,
     ConfigError,
+    InvalidTokenError,
     JWKSError,
     JWKSFetchError,
     JWKSKeyNotFoundError,
@@ -81,6 +82,7 @@ __all__ = [
     "JWKSError",
     "JWKSFetchError",
     "JWKSKeyNotFoundError",
+    "InvalidTokenError",
     # === Data Models ===
     "TokenResponse",
     "ClientRegistrationResponse",

--- a/packages/oauth/src/keycardai/oauth/exceptions.py
+++ b/packages/oauth/src/keycardai/oauth/exceptions.py
@@ -180,3 +180,15 @@ class JWKSFetchError(JWKSError):
 class JWKSKeyNotFoundError(JWKSError):
     """The requested key (`kid`) was not present in the fetched JWKS."""
 
+
+class InvalidTokenError(OAuthError):
+    """A presented token failed verification.
+
+    Raised by the verify surface for any token-validity failure: an
+    unsupported algorithm, a missing ``kid`` header, an untrusted or missing
+    issuer, an expired token, an audience or scope mismatch, or a bad
+    signature. Carries the RFC 6750 ``invalid_token`` error code.
+    """
+
+    error_code = "invalid_token"
+

--- a/packages/oauth/src/keycardai/oauth/server/verifier.py
+++ b/packages/oauth/src/keycardai/oauth/server/verifier.py
@@ -12,8 +12,10 @@ from typing import Any
 
 from pydantic import AnyHttpUrl, BaseModel
 
+from keycardai.oauth.exceptions import InvalidTokenError
 from keycardai.oauth.types.models import ClientConfig
 from keycardai.oauth.utils.jwt import (
+    get_claims,
     get_header,
     get_jwks_key,
     parse_jwt_access_token,
@@ -25,8 +27,6 @@ from .exceptions import (
     CacheError,
     JWKSDiscoveryError,
     JWKSUriValidationError,
-    TokenValidationError,
-    UnsupportedAlgorithmError,
     VerifierConfigError,
 )
 
@@ -51,7 +51,7 @@ class TokenVerifier:
 
     def __init__(
         self,
-        issuer: str,
+        issuer: str | list[str],
         required_scopes: list[str] | None = None,
         jwks_uri: str | None = None,
         allowed_algorithms: list[str] = None,
@@ -75,7 +75,15 @@ class TokenVerifier:
                 stacklevel=2,
             )
             key_ttl = cache_ttl
-        self.issuer = issuer
+        # A single issuer or an allowlist of trusted issuers. The verify surface
+        # accepts a token whose `iss` is any member of the allowlist. `self.issuer`
+        # is the primary issuer, used for multi-zone zone-scoped URL derivation.
+        if isinstance(issuer, str):
+            self._trusted_issuers = {issuer}
+            self.issuer = issuer
+        else:
+            self._trusted_issuers = set(issuer)
+            self.issuer = issuer[0]
         self.required_scopes = required_scopes or []
         self.jwks_uri = jwks_uri
         self.allowed_algorithms = allowed_algorithms
@@ -99,21 +107,27 @@ class TokenVerifier:
         """Deprecated alias for ``key_ttl``."""
         return self.key_ttl
 
-    def _discover_jwks_uri(self, zone_id: str | None = None) -> str:
+    def _discover_jwks_uri(
+        self, issuer: str | None = None, zone_id: str | None = None
+    ) -> str:
         # An explicitly configured jwks_uri is static and bypasses discovery.
         if self.jwks_uri:
             return self.jwks_uri
 
-        cache_key = f"{zone_id or 'default'}"
+        if issuer is not None:
+            cache_key = f"issuer:{issuer}"
+            discovery_issuer = issuer
+        else:
+            cache_key = f"{zone_id or 'default'}"
+            discovery_issuer = self.issuer
+            if self.enable_multi_zone and zone_id:
+                discovery_issuer = self._create_zone_scoped_url(self.issuer, zone_id)
+
         cached = self._discovered_jwks_uris.get(cache_key)
         if cached is not None:
             cached_uri, cached_at = cached
             if time.time() - cached_at < self.discovery_ttl:
                 return cached_uri
-
-        discovery_issuer = self.issuer
-        if self.enable_multi_zone and zone_id:
-            discovery_issuer = self._create_zone_scoped_url(self.issuer, zone_id)
 
         try:
             client = self.client_factory.create_client(
@@ -166,13 +180,16 @@ class TokenVerifier:
         return zone_url
 
     def _get_kid_and_algorithm(self, token: str) -> tuple[str, str]:
-        header = get_header(token)
-        kid = header.get("kid")
+        try:
+            header = get_header(token)
+        except ValueError as e:
+            raise InvalidTokenError("Malformed JWT header") from e
         algorithm = header.get("alg")
         if algorithm not in self.allowed_algorithms:
-            raise UnsupportedAlgorithmError(algorithm)
+            raise InvalidTokenError(f"Unsupported JWT algorithm: {algorithm}")
+        kid = header.get("kid")
         if not kid:
-            raise TokenValidationError("JWT missing key id (kid) header")
+            raise InvalidTokenError("JWT missing key id (kid) header")
         return (kid, algorithm)
 
     def _get_zone_jwks_uri(self, jwks_uri: str, zone_id: str) -> str:
@@ -184,27 +201,29 @@ class TokenVerifier:
         return jwks_url.to_string()
 
     async def _get_verification_key(
-        self, token: str, zone_id: str | None = None
+        self, token: str, zone_id: str | None = None, issuer: str | None = None
     ) -> JWKSKey:
         """Get the verification key for the token, with caching and de-dup.
 
-        Concurrent cold-cache lookups for the same ``(zone, kid)`` share a
-        single in-flight resolution, so a burst of requests triggers one
-        discovery and one JWKS fetch rather than a thundering herd.
+        Keys are cached per ``(issuer, kid)`` so two issuers that happen to
+        share a ``kid`` cannot collide. Concurrent cold-cache lookups for the
+        same key share a single in-flight resolution, so a burst of requests
+        triggers one discovery and one JWKS fetch rather than a thundering herd.
         """
         kid, algorithm = self._get_kid_and_algorithm(token)
 
-        cached_key = self._jwks_cache.get_key(kid)
+        cache_key = f"{issuer}::{kid}" if issuer else kid
+        cached_key = self._jwks_cache.get_key(cache_key)
         if cached_key is not None:
             return cached_key
 
-        inflight_key = f"{zone_id or 'default'}:{kid}"
+        inflight_key = f"{issuer or 'default'}:{zone_id or 'default'}:{kid}"
         existing = self._key_inflight.get(inflight_key)
         if existing is not None:
             return await existing
 
         future = asyncio.ensure_future(
-            self._resolve_and_cache_key(kid, algorithm, zone_id)
+            self._resolve_and_cache_key(kid, algorithm, zone_id, issuer)
         )
         self._key_inflight[inflight_key] = future
         try:
@@ -213,11 +232,17 @@ class TokenVerifier:
             self._key_inflight.pop(inflight_key, None)
 
     async def _resolve_and_cache_key(
-        self, kid: str, algorithm: str, zone_id: str | None = None
+        self,
+        kid: str,
+        algorithm: str,
+        zone_id: str | None = None,
+        issuer: str | None = None,
     ) -> JWKSKey:
         """Discover the jwks_uri, fetch the key for ``kid``, and cache it."""
-        if self.enable_multi_zone and zone_id:
-            jwks_uri = self._discover_jwks_uri(zone_id)
+        if issuer is not None:
+            jwks_uri = self._discover_jwks_uri(issuer=issuer)
+        elif self.enable_multi_zone and zone_id:
+            jwks_uri = self._discover_jwks_uri(zone_id=zone_id)
         else:
             jwks_uri = self._discover_jwks_uri()
             if zone_id:
@@ -227,8 +252,9 @@ class TokenVerifier:
             kid, jwks_uri, timeout=self.fetch_timeout
         )
 
-        self._jwks_cache.set_key(kid, verification_key, algorithm)
-        cached_key = self._jwks_cache.get_key(kid)
+        cache_key = f"{issuer}::{kid}" if issuer else kid
+        self._jwks_cache.set_key(cache_key, verification_key, algorithm)
+        cached_key = self._jwks_cache.get_key(cache_key)
         if cached_key is None:
             raise CacheError("Failed to cache verification key")
         return cached_key
@@ -241,59 +267,103 @@ class TokenVerifier:
         """Get cache statistics for debugging."""
         return self._jwks_cache.get_stats()
 
-    async def verify_token_for_zone(
-        self, token: str, zone_id: str
-    ) -> AccessToken | None:
-        """Verify a JWT token for a specific zone and return AccessToken if valid."""
+    def _unverified_claims(self, token: str) -> dict[str, Any]:
+        """Decode the JWT payload without verifying the signature.
+
+        Used for the cheap policy checks that gate network key resolution.
+        """
         try:
-            key = await self._get_verification_key(token, zone_id)
-            return self._verify_token(token, key, zone_id)
-        except Exception:
-            return None
+            return get_claims(token)
+        except ValueError as e:
+            raise InvalidTokenError("Malformed JWT") from e
 
-    def _verify_token(
-        self, token: str, key: JWKSKey, zone_id: str | None = None
-    ) -> AccessToken | None:
-        jwt_access_token = parse_jwt_access_token(token, key.key, key.algorithm)
+    def _validate_issuer(self, iss: str | None) -> str:
+        """Return the issuer if it is trusted, else raise.
 
-        if jwt_access_token.exp < time.time():
-            return None
+        Enforced against the configured allowlist before any key resolution.
+        """
+        if not iss:
+            raise InvalidTokenError("JWT missing issuer (iss) claim")
+        if iss not in self._trusted_issuers:
+            raise InvalidTokenError("Untrusted issuer")
+        return iss
 
+    def _check_not_expired(self, exp: Any) -> None:
+        if exp is None:
+            raise InvalidTokenError("JWT missing expiration (exp) claim")
+        try:
+            expired = float(exp) < time.time()
+        except (TypeError, ValueError) as e:
+            raise InvalidTokenError("JWT has invalid expiration (exp) claim") from e
+        if expired:
+            raise InvalidTokenError("Token expired")
+
+    async def verify_token(self, token: str) -> AccessToken:
+        """Verify a JWT token and return its ``AccessToken``.
+
+        Cheap policy checks (trusted issuer, expiration, algorithm, ``kid``)
+        run before any network I/O, so a token with an untrusted ``iss`` is
+        rejected without triggering key resolution. The verification key is
+        then resolved for the validated issuer, the signature checked, and the
+        verified claims (issuer, expiration, audience, scopes) confirmed.
+
+        Raises:
+            InvalidTokenError: If the token fails any verification step.
+        """
+        claims = self._unverified_claims(token)
+        issuer = self._validate_issuer(claims.get("iss"))
+        self._check_not_expired(claims.get("exp"))
+
+        key = await self._get_verification_key(token, issuer=issuer)
+        return self._verify_token(token, key, expected_issuer=issuer)
+
+    async def verify_token_for_zone(self, token: str, zone_id: str) -> AccessToken:
+        """Verify a JWT token for a specific zone and return its ``AccessToken``.
+
+        Raises:
+            InvalidTokenError: If the token fails any verification step.
+        """
+        claims = self._unverified_claims(token)
         expected_issuer = self.issuer
         if self.enable_multi_zone and zone_id:
             expected_issuer = self._create_zone_scoped_url(self.issuer, zone_id)
+        if claims.get("iss") != expected_issuer:
+            raise InvalidTokenError("Untrusted issuer")
+        self._check_not_expired(claims.get("exp"))
+
+        key = await self._get_verification_key(token, zone_id)
+        return self._verify_token(
+            token, key, expected_issuer=expected_issuer, zone_id=zone_id
+        )
+
+    def _verify_token(
+        self,
+        token: str,
+        key: JWKSKey,
+        expected_issuer: str,
+        zone_id: str | None = None,
+    ) -> AccessToken:
+        try:
+            jwt_access_token = parse_jwt_access_token(token, key.key, key.algorithm)
+        except ValueError as e:
+            raise InvalidTokenError("Token signature or claims invalid") from e
+
+        if jwt_access_token.exp < time.time():
+            raise InvalidTokenError("Token expired")
 
         if jwt_access_token.iss != expected_issuer:
-            return None
+            raise InvalidTokenError("Untrusted issuer")
 
         if not jwt_access_token.validate_audience(self.audience, zone_id):
-            return None
+            raise InvalidTokenError("Invalid audience")
 
         if not jwt_access_token.validate_scopes(self.required_scopes):
-            return None
-
-        token_scopes = jwt_access_token.get_scopes()
+            raise InvalidTokenError("Insufficient scope")
 
         return AccessToken(
             token=token,
             client_id=jwt_access_token.client_id,
-            scopes=token_scopes,
+            scopes=jwt_access_token.get_scopes(),
             expires_at=jwt_access_token.exp,
             resource=jwt_access_token.get_custom_claim("resource"),
         )
-
-    async def verify_token(self, token: str) -> AccessToken | None:
-        """Verify a JWT token and return AccessToken if valid.
-
-        Performs JWT verification including:
-        - Parse token into structured JWTAccessToken model internally
-        - Validate token expiration
-        - Validate issuer if configured
-        - Validate required scopes if configured
-        - Convert to AccessToken format for return
-        """
-        try:
-            key = await self._get_verification_key(token)
-            return self._verify_token(token, key)
-        except Exception:
-            return None

--- a/packages/oauth/tests/keycardai/oauth/server/test_verifier.py
+++ b/packages/oauth/tests/keycardai/oauth/server/test_verifier.py
@@ -6,12 +6,11 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
-from keycardai.oauth.exceptions import OAuthHttpError
+from keycardai.oauth.exceptions import InvalidTokenError, OAuthHttpError
 from keycardai.oauth.server._cache import JWKSKey
 from keycardai.oauth.server.exceptions import (
     JWKSDiscoveryError,
     JWKSUriValidationError,
-    TokenValidationError,
     VerifierConfigError,
 )
 from keycardai.oauth.server.verifier import AccessToken, TokenVerifier
@@ -59,7 +58,7 @@ class TestTokenVerifierKidRequired:
             "keycardai.oauth.server.verifier.get_header",
             return_value={"alg": "RS256"},
         ):
-            with pytest.raises(TokenValidationError, match="kid"):
+            with pytest.raises(InvalidTokenError, match="kid"):
                 verifier._get_kid_and_algorithm("token")
 
     def test_present_kid_accepted(self):
@@ -135,6 +134,23 @@ class TestTokenVerifierVerifyToken:
 
         return token
 
+    def create_unverified_claims(
+        self,
+        exp: int = None,
+        iss: str = "https://test-issuer.com",
+    ) -> dict:
+        """Build the unverified-claims dict get_claims would return.
+
+        Mirrors the iss/exp of the mocked JWTAccessToken so the cheap pre-checks
+        in verify_token (issuer allowlist, expiration) pass and the flow reaches
+        the signature step.
+        """
+        current_time = int(time.time())
+        return {
+            "iss": iss,
+            "exp": exp if exp is not None else current_time + 3600,
+        }
+
     @pytest.mark.asyncio
     async def test_verify_token_success_basic(self):
         """Test successful token verification with minimal configuration."""
@@ -149,8 +165,10 @@ class TestTokenVerifierVerifyToken:
             algorithm="RS256"
         )
         mock_jwt_token = self.create_mock_jwt_access_token()
+        mock_claims = self.create_unverified_claims()
 
         with patch.object(verifier, '_get_verification_key', new_callable=AsyncMock) as mock_get_key, \
+             patch('keycardai.oauth.server.verifier.get_claims', return_value=mock_claims), \
              patch('keycardai.oauth.server.verifier.parse_jwt_access_token') as mock_parse:
 
             mock_get_key.return_value = mock_key
@@ -166,7 +184,9 @@ class TestTokenVerifierVerifyToken:
             assert result.expires_at == mock_jwt_token.exp
             assert result.resource is None
 
-            mock_get_key.assert_called_once_with("test.jwt.token")
+            mock_get_key.assert_called_once_with(
+                "test.jwt.token", issuer="https://test-issuer.com"
+            )
             mock_parse.assert_called_once_with(
                 "test.jwt.token", "mock-public-key", "RS256"
             )
@@ -187,8 +207,10 @@ class TestTokenVerifierVerifyToken:
         mock_jwt_token = self.create_mock_jwt_access_token(
             custom_claims={"resource": "api.example.com"}
         )
+        mock_claims = self.create_unverified_claims()
 
         with patch.object(verifier, '_get_verification_key', new_callable=AsyncMock) as mock_get_key, \
+             patch('keycardai.oauth.server.verifier.get_claims', return_value=mock_claims), \
              patch('keycardai.oauth.server.verifier.parse_jwt_access_token') as mock_parse:
 
             mock_get_key.return_value = mock_key
@@ -216,16 +238,17 @@ class TestTokenVerifierVerifyToken:
         # Create expired token (1 hour ago)
         expired_time = int(time.time()) - 3600
         mock_jwt_token = self.create_mock_jwt_access_token(exp=expired_time)
+        mock_claims = self.create_unverified_claims(exp=expired_time)
 
         with patch.object(verifier, '_get_verification_key', new_callable=AsyncMock) as mock_get_key, \
+             patch('keycardai.oauth.server.verifier.get_claims', return_value=mock_claims), \
              patch('keycardai.oauth.server.verifier.parse_jwt_access_token') as mock_parse:
 
             mock_get_key.return_value = mock_key
             mock_parse.return_value = mock_jwt_token
 
-            result = await verifier.verify_token("test.jwt.token")
-
-            assert result is None
+            with pytest.raises(InvalidTokenError):
+                await verifier.verify_token("test.jwt.token")
 
     @pytest.mark.asyncio
     async def test_verify_token_wrong_issuer(self):
@@ -243,16 +266,17 @@ class TestTokenVerifierVerifyToken:
         mock_jwt_token = self.create_mock_jwt_access_token(
             iss="https://wrong-issuer.com"
         )
+        mock_claims = self.create_unverified_claims(iss="https://wrong-issuer.com")
 
         with patch.object(verifier, '_get_verification_key', new_callable=AsyncMock) as mock_get_key, \
+             patch('keycardai.oauth.server.verifier.get_claims', return_value=mock_claims), \
              patch('keycardai.oauth.server.verifier.parse_jwt_access_token') as mock_parse:
 
             mock_get_key.return_value = mock_key
             mock_parse.return_value = mock_jwt_token
 
-            result = await verifier.verify_token("test.jwt.token")
-
-            assert result is None
+            with pytest.raises(InvalidTokenError):
+                await verifier.verify_token("test.jwt.token")
 
     @pytest.mark.asyncio
     async def test_verify_token_correct_issuer(self):
@@ -270,8 +294,10 @@ class TestTokenVerifierVerifyToken:
         mock_jwt_token = self.create_mock_jwt_access_token(
             iss="https://expected-issuer.com"
         )
+        mock_claims = self.create_unverified_claims(iss="https://expected-issuer.com")
 
         with patch.object(verifier, '_get_verification_key', new_callable=AsyncMock) as mock_get_key, \
+             patch('keycardai.oauth.server.verifier.get_claims', return_value=mock_claims), \
              patch('keycardai.oauth.server.verifier.parse_jwt_access_token') as mock_parse:
 
             mock_get_key.return_value = mock_key
@@ -299,16 +325,17 @@ class TestTokenVerifierVerifyToken:
         mock_jwt_token = self.create_mock_jwt_access_token(
             scope="read write"  # Missing 'admin' scope
         )
+        mock_claims = self.create_unverified_claims()
 
         with patch.object(verifier, '_get_verification_key', new_callable=AsyncMock) as mock_get_key, \
+             patch('keycardai.oauth.server.verifier.get_claims', return_value=mock_claims), \
              patch('keycardai.oauth.server.verifier.parse_jwt_access_token') as mock_parse:
 
             mock_get_key.return_value = mock_key
             mock_parse.return_value = mock_jwt_token
 
-            result = await verifier.verify_token("test.jwt.token")
-
-            assert result is None
+            with pytest.raises(InvalidTokenError):
+                await verifier.verify_token("test.jwt.token")
 
     @pytest.mark.asyncio
     async def test_verify_token_sufficient_scopes(self):
@@ -327,8 +354,10 @@ class TestTokenVerifierVerifyToken:
         mock_jwt_token = self.create_mock_jwt_access_token(
             scope="read write admin"  # Has required scopes plus extra
         )
+        mock_claims = self.create_unverified_claims()
 
         with patch.object(verifier, '_get_verification_key', new_callable=AsyncMock) as mock_get_key, \
+             patch('keycardai.oauth.server.verifier.get_claims', return_value=mock_claims), \
              patch('keycardai.oauth.server.verifier.parse_jwt_access_token') as mock_parse:
 
             mock_get_key.return_value = mock_key
@@ -353,8 +382,10 @@ class TestTokenVerifierVerifyToken:
             algorithm="RS256"
         )
         mock_jwt_token = self.create_mock_jwt_access_token(scope=None)
+        mock_claims = self.create_unverified_claims()
 
         with patch.object(verifier, '_get_verification_key', new_callable=AsyncMock) as mock_get_key, \
+             patch('keycardai.oauth.server.verifier.get_claims', return_value=mock_claims), \
              patch('keycardai.oauth.server.verifier.parse_jwt_access_token') as mock_parse:
 
             mock_get_key.return_value = mock_key
@@ -380,16 +411,17 @@ class TestTokenVerifierVerifyToken:
             algorithm="RS256"
         )
         mock_jwt_token = self.create_mock_jwt_access_token(scope="")
+        mock_claims = self.create_unverified_claims()
 
         with patch.object(verifier, '_get_verification_key', new_callable=AsyncMock) as mock_get_key, \
+             patch('keycardai.oauth.server.verifier.get_claims', return_value=mock_claims), \
              patch('keycardai.oauth.server.verifier.parse_jwt_access_token') as mock_parse:
 
             mock_get_key.return_value = mock_key
             mock_parse.return_value = mock_jwt_token
 
-            result = await verifier.verify_token("test.jwt.token")
-
-            assert result is None
+            with pytest.raises(InvalidTokenError):
+                await verifier.verify_token("test.jwt.token")
 
     @pytest.mark.asyncio
     async def test_verify_token_get_verification_key_failure(self):
@@ -399,12 +431,16 @@ class TestTokenVerifierVerifyToken:
             jwks_uri="https://example.com/.well-known/jwks.json"
         )
 
-        with patch.object(verifier, '_get_verification_key', new_callable=AsyncMock) as mock_get_key:
+        mock_claims = self.create_unverified_claims()
+
+        with patch.object(verifier, '_get_verification_key', new_callable=AsyncMock) as mock_get_key, \
+             patch('keycardai.oauth.server.verifier.get_claims', return_value=mock_claims):
             mock_get_key.side_effect = Exception("JWKS fetch failed")
 
-            result = await verifier.verify_token("test.jwt.token")
-
-            assert result is None
+            # Key resolution failures are not wrapped; the underlying error
+            # propagates rather than surfacing as InvalidTokenError.
+            with pytest.raises(Exception, match="JWKS fetch failed"):
+                await verifier.verify_token("test.jwt.token")
 
     @pytest.mark.asyncio
     async def test_verify_token_parse_jwt_failure(self):
@@ -419,16 +455,17 @@ class TestTokenVerifierVerifyToken:
             timestamp=time.time(),
             algorithm="RS256"
         )
+        mock_claims = self.create_unverified_claims()
 
         with patch.object(verifier, '_get_verification_key', new_callable=AsyncMock) as mock_get_key, \
+             patch('keycardai.oauth.server.verifier.get_claims', return_value=mock_claims), \
              patch('keycardai.oauth.server.verifier.parse_jwt_access_token') as mock_parse:
 
             mock_get_key.return_value = mock_key
-            mock_parse.side_effect = Exception("Invalid JWT signature")
+            mock_parse.side_effect = ValueError("Invalid JWT signature")
 
-            result = await verifier.verify_token("test.jwt.token")
-
-            assert result is None
+            with pytest.raises(InvalidTokenError):
+                await verifier.verify_token("test.jwt.token")
 
     @pytest.mark.asyncio
     async def test_verify_token_complex_scenario(self):
@@ -454,8 +491,10 @@ class TestTokenVerifierVerifyToken:
                 "role": "admin"
             }
         )
+        mock_claims = self.create_unverified_claims(iss="https://keycard.ai")
 
         with patch.object(verifier, '_get_verification_key', new_callable=AsyncMock) as mock_get_key, \
+             patch('keycardai.oauth.server.verifier.get_claims', return_value=mock_claims), \
              patch('keycardai.oauth.server.verifier.parse_jwt_access_token') as mock_parse:
 
             mock_get_key.return_value = mock_key
@@ -490,22 +529,26 @@ class TestTokenVerifierVerifyToken:
         with patch('keycardai.oauth.server.verifier.time.time') as mock_time:
             mock_time.return_value = current_time
             mock_jwt_token = self.create_mock_jwt_access_token(exp=current_time - 1)
+            mock_claims = self.create_unverified_claims(exp=current_time - 1)
 
             with patch.object(verifier, '_get_verification_key', new_callable=AsyncMock) as mock_get_key, \
+                 patch('keycardai.oauth.server.verifier.get_claims', return_value=mock_claims), \
                  patch('keycardai.oauth.server.verifier.parse_jwt_access_token') as mock_parse:
 
                 mock_get_key.return_value = mock_key
                 mock_parse.return_value = mock_jwt_token
 
-                result = await verifier.verify_token("test.jwt.token")
-                assert result is None
+                with pytest.raises(InvalidTokenError):
+                    await verifier.verify_token("test.jwt.token")
 
         # Test token expiring in the future (should be accepted)
         with patch('keycardai.oauth.server.verifier.time.time') as mock_time:
             mock_time.return_value = current_time
             mock_jwt_token = self.create_mock_jwt_access_token(exp=current_time + 1)
+            mock_claims = self.create_unverified_claims(exp=current_time + 1)
 
             with patch.object(verifier, '_get_verification_key', new_callable=AsyncMock) as mock_get_key, \
+                 patch('keycardai.oauth.server.verifier.get_claims', return_value=mock_claims), \
                  patch('keycardai.oauth.server.verifier.parse_jwt_access_token') as mock_parse:
 
                 mock_get_key.return_value = mock_key
@@ -530,8 +573,10 @@ class TestTokenVerifierVerifyToken:
             algorithm="RS256"
         )
         mock_jwt_token = self.create_mock_jwt_access_token(scope="any scope")
+        mock_claims = self.create_unverified_claims()
 
         with patch.object(verifier, '_get_verification_key', new_callable=AsyncMock) as mock_get_key, \
+             patch('keycardai.oauth.server.verifier.get_claims', return_value=mock_claims), \
              patch('keycardai.oauth.server.verifier.parse_jwt_access_token') as mock_parse:
 
             mock_get_key.return_value = mock_key
@@ -547,8 +592,10 @@ class TestTokenVerifierVerifyToken:
             jwks_uri="https://example.com/.well-known/jwks.json"
         )
         mock_jwt_token = self.create_mock_jwt_access_token(scope="exact match")
+        mock_claims = self.create_unverified_claims()
 
         with patch.object(verifier, '_get_verification_key', new_callable=AsyncMock) as mock_get_key, \
+             patch('keycardai.oauth.server.verifier.get_claims', return_value=mock_claims), \
              patch('keycardai.oauth.server.verifier.parse_jwt_access_token') as mock_parse:
 
             mock_get_key.return_value = mock_key
@@ -574,42 +621,48 @@ class TestTokenVerifierVerifyToken:
 
     @pytest.mark.asyncio
     async def test_verify_token_for_zone_invalid_zone_id(self):
-        """Test that invalid zone_id returns None instead of raising exception."""
+        """A 404 from key resolution propagates (verify no longer swallows it)."""
         verifier = TokenVerifier(
             issuer="https://keycard.cloud",
             enable_multi_zone=True
         )
+        mock_claims = self.create_unverified_claims(
+            iss="https://invalid-zone-id.keycard.cloud"
+        )
 
-        # Mock _get_verification_key to raise OAuthHttpError with 404 (simulating invalid zone)
-        with patch.object(verifier, '_get_verification_key', new_callable=AsyncMock) as mock_get_key:
+        with patch.object(verifier, '_get_verification_key', new_callable=AsyncMock) as mock_get_key, \
+             patch('keycardai.oauth.server.verifier.get_claims', return_value=mock_claims):
             mock_get_key.side_effect = OAuthHttpError(
                 status_code=404,
                 response_body="Not Found",
                 operation="GET /.well-known/oauth-authorization-server"
             )
 
-            result = await verifier.verify_token_for_zone("test.jwt.token", "invalid-zone-id")
+            with pytest.raises(OAuthHttpError):
+                await verifier.verify_token_for_zone("test.jwt.token", "invalid-zone-id")
 
-            assert result is None
             mock_get_key.assert_called_once_with("test.jwt.token", "invalid-zone-id")
 
     @pytest.mark.asyncio
     async def test_verify_token_for_zone_discovery_error(self):
-        """Test that JWKS discovery error returns None instead of raising exception."""
+        """A JWKS discovery error from key resolution propagates."""
         verifier = TokenVerifier(
             issuer="https://keycard.cloud",
             enable_multi_zone=True
         )
+        mock_claims = self.create_unverified_claims(
+            iss="https://invalid-zone.keycard.cloud"
+        )
 
-        # Mock _get_verification_key to raise JWKSDiscoveryError from discovery failure
-        with patch.object(verifier, '_get_verification_key', new_callable=AsyncMock) as mock_get_key:
+        with patch.object(verifier, '_get_verification_key', new_callable=AsyncMock) as mock_get_key, \
+             patch('keycardai.oauth.server.verifier.get_claims', return_value=mock_claims):
             mock_get_key.side_effect = JWKSDiscoveryError(
                 "http://invalid.keycard.cloud", "invalid-zone"
             )
 
-            result = await verifier.verify_token_for_zone("test.jwt.token", "invalid-zone")
+            with pytest.raises(JWKSDiscoveryError):
+                await verifier.verify_token_for_zone("test.jwt.token", "invalid-zone")
 
-            assert result is None
             mock_get_key.assert_called_once_with("test.jwt.token", "invalid-zone")
 
     @pytest.mark.asyncio
@@ -619,37 +672,47 @@ class TestTokenVerifierVerifyToken:
             issuer="https://keycard.cloud",
             enable_multi_zone=True
         )
+        mock_claims = self.create_unverified_claims(
+            iss="https://some-zone-id.keycard.cloud"
+        )
 
-        # Mock _get_verification_key to raise OAuthHttpError with 500 (should propagate)
-        with patch.object(verifier, '_get_verification_key', new_callable=AsyncMock) as mock_get_key:
+        with patch.object(verifier, '_get_verification_key', new_callable=AsyncMock) as mock_get_key, \
+             patch('keycardai.oauth.server.verifier.get_claims', return_value=mock_claims):
             mock_get_key.side_effect = OAuthHttpError(
                 status_code=500,
                 response_body="Internal Server Error",
                 operation="GET /.well-known/oauth-authorization-server"
             )
 
-            access_token = await verifier.verify_token_for_zone("test.jwt.token", "some-zone-id")
+            with pytest.raises(OAuthHttpError):
+                await verifier.verify_token_for_zone("test.jwt.token", "some-zone-id")
 
-            assert access_token is None
             mock_get_key.assert_called_once_with("test.jwt.token", "some-zone-id")
 
     @pytest.mark.asyncio
-    async def test_verify_token_for_zone_value_errors_converted_to_token_validation_error(self):
-        """Test that ValueError are converted to TokenValidationError for proper error handling."""
+    async def test_verify_token_for_zone_key_resolution_value_error_propagates(self):
+        """A ValueError from key resolution propagates unchanged.
+
+        Only ValueErrors from ``parse_jwt_access_token`` (inside ``_verify_token``)
+        are wrapped as ``InvalidTokenError``; failures during key resolution are not.
+        """
         verifier = TokenVerifier(
             issuer="https://keycard.cloud",
             enable_multi_zone=True
         )
+        mock_claims = self.create_unverified_claims(
+            iss="https://some-zone-id.keycard.cloud"
+        )
 
-        # Mock _get_verification_key to raise ValueError (should be wrapped as TokenValidationError)
-        with patch.object(verifier, '_get_verification_key', new_callable=AsyncMock) as mock_get_key:
+        with patch.object(verifier, '_get_verification_key', new_callable=AsyncMock) as mock_get_key, \
+             patch('keycardai.oauth.server.verifier.get_claims', return_value=mock_claims):
             mock_get_key.side_effect = ValueError(
                 "JWT parsing failed"
             )
 
-            access_token = await verifier.verify_token_for_zone("test.jwt.token", "some-zone-id")
+            with pytest.raises(ValueError, match="JWT parsing failed"):
+                await verifier.verify_token_for_zone("test.jwt.token", "some-zone-id")
 
-            assert access_token is None
             mock_get_key.assert_called_once_with("test.jwt.token", "some-zone-id")
 
     @pytest.mark.asyncio
@@ -668,8 +731,12 @@ class TestTokenVerifierVerifyToken:
         mock_jwt_token = self.create_mock_jwt_access_token(
             iss="https://zone1.keycard.cloud"  # Zone-scoped issuer
         )
+        mock_claims = self.create_unverified_claims(
+            iss="https://zone1.keycard.cloud"
+        )
 
         with patch.object(verifier, '_get_verification_key', new_callable=AsyncMock) as mock_get_key, \
+             patch('keycardai.oauth.server.verifier.get_claims', return_value=mock_claims), \
              patch('keycardai.oauth.server.verifier.parse_jwt_access_token') as mock_parse:
 
             mock_get_key.return_value = mock_key
@@ -682,6 +749,88 @@ class TestTokenVerifierVerifyToken:
             assert result.token == "test.jwt.token"
             assert result.client_id == "test-client"
             mock_get_key.assert_called_once_with("test.jwt.token", "zone1")
+
+    @pytest.mark.asyncio
+    async def test_untrusted_issuer_rejected_before_key_resolution(self):
+        """An untrusted issuer is rejected before any network key resolution."""
+        verifier = TokenVerifier(
+            issuer="https://trusted.example.com",
+            jwks_uri="https://trusted.example.com/.well-known/jwks.json",
+        )
+        mock_claims = self.create_unverified_claims(
+            iss="https://evil.example.com"
+        )
+
+        with patch.object(verifier, '_get_verification_key', new_callable=AsyncMock) as mock_get_key, \
+             patch('keycardai.oauth.server.verifier.get_claims', return_value=mock_claims):
+            with pytest.raises(InvalidTokenError):
+                await verifier.verify_token("test.jwt.token")
+
+            mock_get_key.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_issuer_allowlist_accepts_any_trusted_issuer(self):
+        """An allowlist accepts a token whose iss is any member, rejects others."""
+        verifier = TokenVerifier(
+            issuer=["https://a.example.com", "https://b.example.com"],
+            jwks_uri="https://a.example.com/.well-known/jwks.json",
+        )
+
+        mock_key = JWKSKey(
+            key="mock-public-key",
+            timestamp=time.time(),
+            algorithm="RS256",
+        )
+
+        # A token issued by an allowlisted issuer (the second one) succeeds.
+        trusted_token = self.create_mock_jwt_access_token(iss="https://b.example.com")
+        trusted_claims = self.create_unverified_claims(iss="https://b.example.com")
+        with patch.object(verifier, '_get_verification_key', new_callable=AsyncMock) as mock_get_key, \
+             patch('keycardai.oauth.server.verifier.get_claims', return_value=trusted_claims), \
+             patch('keycardai.oauth.server.verifier.parse_jwt_access_token') as mock_parse:
+
+            mock_get_key.return_value = mock_key
+            mock_parse.return_value = trusted_token
+
+            result = await verifier.verify_token("test.jwt.token")
+            assert isinstance(result, AccessToken)
+
+        # A token issued by an issuer not on the allowlist is rejected.
+        untrusted_claims = self.create_unverified_claims(iss="https://c.example.com")
+        with patch.object(verifier, '_get_verification_key', new_callable=AsyncMock) as mock_get_key, \
+             patch('keycardai.oauth.server.verifier.get_claims', return_value=untrusted_claims):
+            with pytest.raises(InvalidTokenError):
+                await verifier.verify_token("test.jwt.token")
+
+            mock_get_key.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_verify_token_returns_access_token_never_none(self):
+        """verify_token returns an AccessToken on success (never None)."""
+        verifier = TokenVerifier(
+            issuer="https://test-issuer.com",
+            jwks_uri="https://example.com/.well-known/jwks.json",
+        )
+
+        mock_key = JWKSKey(
+            key="mock-public-key",
+            timestamp=time.time(),
+            algorithm="RS256",
+        )
+        mock_jwt_token = self.create_mock_jwt_access_token()
+        mock_claims = self.create_unverified_claims()
+
+        with patch.object(verifier, '_get_verification_key', new_callable=AsyncMock) as mock_get_key, \
+             patch('keycardai.oauth.server.verifier.get_claims', return_value=mock_claims), \
+             patch('keycardai.oauth.server.verifier.parse_jwt_access_token') as mock_parse:
+
+            mock_get_key.return_value = mock_key
+            mock_parse.return_value = mock_jwt_token
+
+            result = await verifier.verify_token("test.jwt.token")
+
+            assert result is not None
+            assert isinstance(result, AccessToken)
 
 
 class TestTokenVerifierCacheKnobs:

--- a/packages/starlette/src/keycardai/starlette/middleware/bearer.py
+++ b/packages/starlette/src/keycardai/starlette/middleware/bearer.py
@@ -14,6 +14,7 @@ from collections.abc import Sequence
 
 from pydantic import AnyHttpUrl
 
+from keycardai.oauth.exceptions import InvalidTokenError
 from keycardai.oauth.server.verifier import TokenVerifier
 from starlette.authentication import (
     AuthCredentials,
@@ -211,13 +212,17 @@ class KeycardAuthBackend(AuthenticationBackend):
             if zone_id is None:
                 raise KeycardAuthError("invalid_token", "Zone ID is required")
 
-        if self.verifier.enable_multi_zone and zone_id:
-            access_token = await self.verifier.verify_token_for_zone(token, zone_id)
-        else:
-            access_token = await self.verifier.verify_token(token)
-
-        if access_token is None:
-            raise KeycardAuthError("invalid_token", "Token verification failed")
+        try:
+            if self.verifier.enable_multi_zone and zone_id:
+                access_token = await self.verifier.verify_token_for_zone(
+                    token, zone_id
+                )
+            else:
+                access_token = await self.verifier.verify_token(token)
+        except InvalidTokenError as e:
+            raise KeycardAuthError(
+                "invalid_token", "Token verification failed"
+            ) from e
 
         resource_server_url = _get_oauth_protected_resource_url(conn)
         user = KeycardUser(

--- a/packages/starlette/tests/keycardai/starlette/test_provider.py
+++ b/packages/starlette/tests/keycardai/starlette/test_provider.py
@@ -9,6 +9,7 @@ from starlette.middleware.authentication import AuthenticationMiddleware
 from starlette.requests import HTTPConnection, Request
 from starlette.testclient import TestClient
 
+from keycardai.oauth.exceptions import InvalidTokenError
 from keycardai.oauth.server import AccessContext
 from keycardai.oauth.server.credentials import ClientSecret
 from keycardai.oauth.server.exceptions import (
@@ -229,7 +230,9 @@ class TestKeycardAuthBackend:
         """
         verifier = MagicMock(
             enable_multi_zone=False,
-            verify_token=AsyncMock(return_value=None),
+            verify_token=AsyncMock(
+                side_effect=InvalidTokenError("Token verification failed")
+            ),
         )
         backend = KeycardAuthBackend(verifier)
         scope = {
@@ -270,7 +273,9 @@ class TestKeycardAuthBackend:
         )
         verifier = MagicMock(
             enable_multi_zone=False,
-            verify_token=AsyncMock(return_value=None),
+            verify_token=AsyncMock(
+                side_effect=InvalidTokenError("Token verification failed")
+            ),
         )
         provider.get_token_verifier = MagicMock(return_value=verifier)  # type: ignore[method-assign]
 


### PR DESCRIPTION
Resolves the addressable Python rows of the **jwt-signing-and-verification** spec (keycard-sdk-spec#16, ECO-36): the verify surface becomes fail-closed and typed, enforces the trusted issuer before key resolution, and supports an issuer allowlist. Mirrors the contract of the TS `JWTVerifier`.

## `keycardai-oauth` (breaking)
- New `InvalidTokenError` (RFC 6750 `invalid_token`), exported from the package root.
- `verify_token` / `verify_token_for_zone` now return `AccessToken` and **raise `InvalidTokenError`** on any verification failure. They no longer return `None`.
- Cheap policy checks (trusted issuer, expiration) run on the unverified payload **before** any network key resolution, so a token with an untrusted `iss` is rejected without triggering JWKS discovery/fetch.
- `issuer` now accepts `str | list[str]` (trusted-issuer allowlist). JWKS keys are cached per `(issuer, kid)`, and discovery resolves keys for the validated token issuer.
- JWKS infra errors (discovery/fetch) propagate as their typed errors instead of being collapsed into a generic failure, so a JWKS outage surfaces as a server error rather than a misleading invalid-token result.

## `keycardai-starlette`
- The bearer backend catches `InvalidTokenError` and maps it to the RFC 6750 `invalid_token` 401 challenge. JWKS infra errors are no longer caught here (they surface as 5xx rather than 401).

## Scope notes
- Multi-zone issuer handling is unchanged (left for the multi-zone spec / ECO-81).
- No clock-skew leeway added: TS and Python already match (exact comparison); only Go differs, tracked separately.
- Required-claims alignment (ECO-36's remaining row) is the TS side and ships in a separate typescript-sdk PR.

## Release note
Two package-scoped commits (`feat(keycardai-oauth)!`, `fix(keycardai-starlette)`). **Merge with a merge commit to release both packages.** A squash merge would only release `keycardai-oauth` (the title scope); `keycardai-starlette` would then need its own release, since the published starlette's old `None` check is incompatible with the new oauth (the raised `InvalidTokenError` would go uncaught).

## Tests
oauth 259 pass, starlette 84 pass. Added: untrusted issuer is rejected before key resolution (proves the reorder), the allowlist accepts any trusted issuer and rejects others, and the verify surface returns an `AccessToken` (never `None`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
