### PR TITLE
feat(keycardai-oauth)!: RFC-minimal client registration and typed registration errors

### DIFF
--- a/packages/oauth/src/keycardai/oauth/client.py
+++ b/packages/oauth/src/keycardai/oauth/client.py
@@ -530,7 +530,7 @@ class AsyncClient:
             ClientRegistrationResponse with client credentials and metadata
 
         Raises:
-            TypeError: If both request and client_registration_args are provided, or client_name is empty
+            TypeError: If both request and client_registration_args are provided
             ValidationError: If request model validation fails (e.g., empty required fields)
             OAuthHttpError: If registration endpoint returns HTTP error (4xx/5xx)
             OAuthProtocolError: If registration response is invalid or contains OAuth errors
@@ -539,8 +539,6 @@ class AsyncClient:
             raise TypeError("Pass either `request` or keyword arguments, not both.")
 
         if request is None:
-            if not client_registration_args.get("client_name"):
-                raise TypeError("client_name is required when not using a request object")
             request = ClientRegistrationRequest(**client_registration_args)
 
         endpoints = await self._get_current_endpoints()
@@ -1113,7 +1111,7 @@ class Client:
             ClientRegistrationResponse with client credentials and metadata
 
         Raises:
-            TypeError: If both request and client_registration_args are provided, or client_name is empty
+            TypeError: If both request and client_registration_args are provided
             ValidationError: If request model validation fails (e.g., empty required fields)
             OAuthHttpError: If registration endpoint returns HTTP error (4xx/5xx)
             OAuthProtocolError: If registration response is invalid or contains OAuth errors
@@ -1122,8 +1120,6 @@ class Client:
             raise TypeError("Pass either `request` or keyword arguments, not both.")
 
         if request is None:
-            if not client_registration_args.get("client_name"):
-                raise TypeError("client_name is required when not using a request object")
             request = ClientRegistrationRequest(**client_registration_args)
 
         endpoints = self._get_current_endpoints()

--- a/packages/oauth/src/keycardai/oauth/operations/_registration.py
+++ b/packages/oauth/src/keycardai/oauth/operations/_registration.py
@@ -29,6 +29,21 @@ def parse_client_registration_http_response(res: HttpResponse) -> ClientRegistra
     """Parse HTTP response from OAuth 2.0 Dynamic Client Registration endpoint."""
     # TODO: Handle errors more granularly
     if res.status >= 400:
+        # RFC 7591 §3.2.2: a registration error is HTTP 400 with a JSON body
+        # carrying an `error` code. Surface it as a typed protocol error so a
+        # caller can branch on the code; fall back to the raw HTTP error when
+        # the body is not a structured OAuth error.
+        try:
+            error_data = json.loads(res.body.decode("utf-8"))
+        except Exception:
+            error_data = None
+        if isinstance(error_data, dict) and "error" in error_data:
+            raise OAuthProtocolError(
+                error=error_data["error"],
+                error_description=error_data.get("error_description"),
+                error_uri=error_data.get("error_uri"),
+                operation="POST /register",
+            )
         response_body = res.body[:512].decode("utf-8", "ignore")
         raise OAuthHttpError(
             status_code=res.status,

--- a/packages/oauth/src/keycardai/oauth/types/models.py
+++ b/packages/oauth/src/keycardai/oauth/types/models.py
@@ -146,19 +146,11 @@ class ClientRegistrationRequest(OAuthClientMetadata):
     """Dynamic Client Registration Request as defined in RFC 7591 Section 2.
 
     Reference: https://datatracker.ietf.org/doc/html/rfc7591#section-2
+
+    Per RFC 7591 all client metadata is optional and is inherited from
+    OAuthClientMetadata. The request sends only the fields the caller sets and
+    injects no defaults.
     """
-    # Override with required field
-    client_name: str = Field(..., min_length=1, description="Human-readable name of the client application.")
-
-    # Override with defaults for registration
-    token_endpoint_auth_method: TokenEndpointAuthMethod = (
-        TokenEndpointAuthMethod.CLIENT_SECRET_BASIC
-    )
-    redirect_uris: list[str] | None = Field(default_factory=lambda: ["http://localhost:8080/callback"])
-    grant_types: list[GrantType] | None = Field(default_factory=lambda: [GrantType.TOKEN_EXCHANGE, GrantType.CLIENT_CREDENTIALS])
-    response_types: list[ResponseType] | None = Field(default_factory=lambda: [ResponseType.CODE])
-    scope: str | None = "read write"
-
     # Request-specific fields
     client_id: str | None = None
     timeout: float | None = None

--- a/packages/oauth/tests/keycardai/oauth/operations/test_registration.py
+++ b/packages/oauth/tests/keycardai/oauth/operations/test_registration.py
@@ -88,6 +88,52 @@ class TestRegistrationOperations:
         assert len(body_data["redirect_uris"]) == 2
         assert "authorization_code" in body_data["grant_types"]
 
+    def test_minimal_request_omits_unset_defaults(self):
+        """An RFC-minimal request injects no defaults into the POST body."""
+        req = ClientRegistrationRequest(client_name="My App")
+
+        mock_auth = Mock()
+        mock_auth.apply_headers.return_value = {}
+
+        context = build_http_context(
+            endpoint="https://auth.example.com/register",
+            transport=Mock(),
+            auth=mock_auth,
+            user_agent="TestClient/1.0",
+        )
+
+        http_req = build_client_registration_http_request(req, context)
+        body_data = json.loads(http_req.body.decode("utf-8"))
+
+        assert body_data == {"client_name": "My App"}
+        for omitted in (
+            "redirect_uris",
+            "scope",
+            "grant_types",
+            "response_types",
+            "token_endpoint_auth_method",
+        ):
+            assert omitted not in body_data
+
+    def test_minimal_request_model_dump_omits_unset_defaults(self):
+        """The minimal request serializes without injected RFC defaults."""
+        req = ClientRegistrationRequest(client_name="My App")
+
+        dumped = req.model_dump(mode="json", exclude_none=True, exclude={"timeout"})
+
+        assert dumped == {"client_name": "My App"}
+
+    def test_request_without_client_name_is_valid(self):
+        """client_name is optional; an empty request raises no ValidationError."""
+        req = ClientRegistrationRequest()
+
+        assert req.client_name is None
+        assert req.redirect_uris is None
+        assert req.scope is None
+        assert req.grant_types is None
+        assert req.response_types is None
+        assert req.token_endpoint_auth_method is None
+
     def test_parse_registration_http_response_success(self):
         """Test parsing successful registration response."""
         response_body = b'''{
@@ -113,12 +159,37 @@ class TestRegistrationOperations:
         assert result.client_secret == "generated_secret_456"
         assert result.client_name == "Test Client"
 
-    def test_parse_registration_http_response_http_error(self):
-        """Test parsing HTTP error response."""
+    def test_parse_registration_http_response_protocol_error(self):
+        """A 4xx with an RFC 7591 error body raises OAuthProtocolError."""
         http_response = HttpResponse(
             status=400,
             headers={"Content-Type": "application/json"},
-            body=b'{"error": "invalid_request", "error_description": "Missing client_name"}'
+            body=b'{"error": "invalid_client_metadata", "error_description": "bad redirect_uri"}'
+        )
+
+        with pytest.raises(OAuthProtocolError) as exc_info:
+            parse_client_registration_http_response(http_response)
+
+        assert exc_info.value.error == "invalid_client_metadata"
+        assert exc_info.value.error_description == "bad redirect_uri"
+
+    def test_parse_registration_http_response_non_json_error(self):
+        """A 4xx with a non-JSON body falls back to OAuthHttpError."""
+        http_response = HttpResponse(
+            status=400,
+            headers={"Content-Type": "text/plain"},
+            body=b"Bad Request"
+        )
+
+        with pytest.raises(OAuthHttpError, match="HTTP 400"):
+            parse_client_registration_http_response(http_response)
+
+    def test_parse_registration_http_response_json_without_error_key(self):
+        """A 4xx JSON body without an `error` key falls back to OAuthHttpError."""
+        http_response = HttpResponse(
+            status=400,
+            headers={"Content-Type": "application/json"},
+            body=b'{"message": "something went wrong"}'
         )
 
         with pytest.raises(OAuthHttpError, match="HTTP 400"):

--- a/packages/oauth/tests/keycardai/oauth/test_client.py
+++ b/packages/oauth/tests/keycardai/oauth/test_client.py
@@ -438,28 +438,14 @@ class TestOverloadEquivalence:
 class TestClientValidation:
     """Test client validation behavior with Pydantic models."""
 
-    def test_register_client_empty_client_name_validation(self):
-        """Test that register_client rejects empty client_name with TypeError."""
+    def test_register_client_empty_client_name_accepted(self):
+        """client_name is optional (RFC-minimal): an empty client_name passes client-level validation and reaches the register call."""
         client = Client("https://test.keycard.cloud", config=ClientConfig(enable_metadata_discovery=False, auto_register_client=False))
 
-        # Test that empty string client_name raises TypeError (client-level validation)
-        with pytest.raises(TypeError) as exc_info:
+        with patch('keycardai.oauth.client.register_client') as mock_register:
+            mock_register.return_value = Mock()
             client.register_client(client_name="")
-
-        # Verify the error message
-        assert "client_name is required" in str(exc_info.value)
-
-    @pytest.mark.asyncio
-    async def test_async_register_client_empty_client_name_validation(self):
-        """Test that async register_client rejects empty client_name with TypeError."""
-        async_client = AsyncClient("https://test.keycard.cloud", config=ClientConfig(enable_metadata_discovery=False, auto_register_client=False))
-
-        # Test that empty string client_name raises TypeError (client-level validation)
-        with pytest.raises(TypeError) as exc_info:
-            await async_client.register_client(client_name="")
-
-        # Verify the error message
-        assert "client_name is required" in str(exc_info.value)
+            mock_register.assert_called_once()
 
     def test_register_client_whitespace_only_client_name_validation(self):
         """Test that register_client accepts whitespace-only client_name (passes client validation but may fail at server)."""
@@ -473,18 +459,14 @@ class TestClientValidation:
             # If we get here, client validation passed
             mock_register.assert_called_once()
 
-    def test_pydantic_model_empty_client_name_validation(self):
-        """Test that ClientRegistrationRequest model directly validates empty client_name."""
-        # Test Pydantic validation directly on the model
-        with pytest.raises(ValidationError) as exc_info:
-            ClientRegistrationRequest(client_name="")
+    def test_pydantic_model_client_name_optional(self):
+        """ClientRegistrationRequest is RFC-minimal: client_name is optional.
 
-        # Verify the error is about string length
-        error = exc_info.value
-        assert len(error.errors()) == 1
-        assert error.errors()[0]["type"] == "string_too_short"
-        assert error.errors()[0]["loc"] == ("client_name",)
-        assert "at least 1 character" in str(error.errors()[0]["msg"])
+        Per RFC 7591 all client metadata is optional, so the model accepts an
+        empty string or an omitted client_name without raising.
+        """
+        assert ClientRegistrationRequest(client_name="").client_name == ""
+        assert ClientRegistrationRequest().client_name is None
 
     def test_token_exchange_request_validation(self):
         """Test that TokenExchangeRequest model validates required fields and handles kwargs correctly."""


### PR DESCRIPTION
The Python half of #23 DCR (ECO-44). Per your decisions: **RFC-minimal request** (drop Python's injected defaults) and **client_name optional**, plus the typed-error fix.

## Changes (`keycardai-oauth`)
- **RFC-minimal request:** `ClientRegistrationRequest` no longer injects `token_endpoint_auth_method=client_secret_basic`, `redirect_uris=[http://localhost:8080/callback]`, `grant_types=[token-exchange, client_credentials]`, `response_types=[code]`, or `scope="read write"`. It inherits all metadata (optional, `None`) from `OAuthClientMetadata` and sends only what the caller sets (`model_dump(exclude_none=True)`). Matches the RFC-minimal TS `registerClient`.
- **`client_name` optional:** dropped the `Field(..., min_length=1)` override (now inherited `str | None = None`) and removed the client-level `TypeError("client_name is required")` checks on both `register_client` paths (sync + async). Aligns with RFC 7591 and TS.
- **Typed registration errors:** on an RFC 7591 §3.2.2 error (4xx + JSON `error` body) registration now raises `OAuthProtocolError` carrying the `error` code (previously the typed branch was unreachable for 4xx and it raised an opaque `OAuthHttpError`). A non-structured 4xx still raises `OAuthHttpError`.

## Scope
- The `auto_register_client` convenience path is unaffected (it passes explicit config values; it never sent `response_types`/`scope`, which were authorization-code fields a token-exchange client doesn't use).
- The `issuerUrl`→`issuer` row is already resolved by the merged ECO-33.
- Go DCR (not implemented) stays on the Go effort.

## Tests
oauth suite green (exit 0). Added: minimal request omits the dropped defaults; `client_name` omitted/empty is accepted; 4xx + RFC 7591 error body → `OAuthProtocolError` with the parsed `error` code; non-structured 4xx → `OAuthHttpError`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
