### PR TITLE
fix(keycardai-starlette): emit RFC 6750 insufficient_scope challenge from requires

### DIFF
--- a/packages/starlette/src/keycardai/starlette/authorization.py
+++ b/packages/starlette/src/keycardai/starlette/authorization.py
@@ -28,7 +28,6 @@ from keycardai.oauth.server.exceptions import MissingAccessContextError
 from keycardai.oauth.server.token_exchange import exchange_tokens_for_resources
 from starlette._utils import is_async_callable
 from starlette.authentication import has_required_scope
-from starlette.exceptions import HTTPException
 from starlette.requests import Request
 
 from .middleware.bearer import (
@@ -63,8 +62,9 @@ def requires(
       that includes the ``resource_metadata=`` URL (RFC 9728) computed from
       the current request, instead of stock ``HTTPException(403)``.
     - If the user is authenticated but missing one of the required scopes,
-      raises ``HTTPException(status_code)`` (default 403), matching the
-      stock decorator's "authenticated but unauthorized" behavior.
+      returns a 403 (configurable via ``status_code``) carrying an RFC 6750
+      ``WWW-Authenticate: Bearer error="insufficient_scope"`` challenge with
+      the ``resource_metadata=`` URL (RFC 9728).
 
     The ``redirect`` argument from stock ``requires`` is intentionally
     omitted - browser redirects do not apply to OAuth 2.0 protected
@@ -101,7 +101,12 @@ def requires(
                 if not request.user.is_authenticated:
                     return _build_unauthorized_response(request)
                 if not has_required_scope(request, scopes_list):
-                    raise HTTPException(status_code=status_code)
+                    return _build_unauthorized_response(
+                        request,
+                        error="insufficient_scope",
+                        description="Insufficient scope",
+                        status_code=status_code,
+                    )
                 return await func(*args, **kwargs)
 
             return async_wrapper
@@ -120,7 +125,12 @@ def requires(
             if not request.user.is_authenticated:
                 return _build_unauthorized_response(request)
             if not has_required_scope(request, scopes_list):
-                raise HTTPException(status_code=status_code)
+                return _build_unauthorized_response(
+                    request,
+                    error="insufficient_scope",
+                    description="Insufficient scope",
+                    status_code=status_code,
+                )
             return func(*args, **kwargs)
 
         return sync_wrapper

--- a/packages/starlette/tests/keycardai/starlette/test_provider.py
+++ b/packages/starlette/tests/keycardai/starlette/test_provider.py
@@ -377,6 +377,10 @@ class TestRequires:
             "/api/admin", headers={"Authorization": "Bearer some-token"}
         )
         assert response.status_code == 403
+        challenge = response.headers.get("WWW-Authenticate", "")
+        assert challenge.startswith("Bearer")
+        assert 'error="insufficient_scope"' in challenge
+        assert "resource_metadata=" in challenge
 
 
 class TestGrant:


### PR DESCRIPTION
Resolves the only addressable Py/TS row of #27 route-level-auth-gating (ECO-78).

## Change (`keycardai-starlette`)
The `requires` decorator raised a bare `HTTPException(403)` on scope failure, with no `WWW-Authenticate` header. It now returns a 403 carrying an RFC 6750 `Bearer error="insufficient_scope"` challenge with the `resource_metadata=` URL (RFC 9728) — matching the decorator's own 401 anonymous path (which already emitted the challenge) and the TS (`InsufficientScopeError`) / Go route gates. The configurable `status_code` (default 403) still controls the failure status.

Reuses the existing `_build_unauthorized_response` challenge builder (parameterized by `error` + `status_code`), so the 403 carries the same `resource_metadata` URL the 401 does.

## Tests
starlette suite green. Strengthened `test_insufficient_scope_returns_403` to assert the 403 now carries `WWW-Authenticate: Bearer ... error="insufficient_scope" ... resource_metadata=...`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
