### PR TITLE
feat(keycardai-oauth): expose get_client_jwks_url on the WebIdentity credential

### DIFF
--- a/packages/oauth/src/keycardai/oauth/server/credentials.py
+++ b/packages/oauth/src/keycardai/oauth/server/credentials.py
@@ -233,6 +233,14 @@ class WebIdentity:
     def get_jwks(self) -> JsonWebKeySet:
         return self.identity_manager.get_jwks()
 
+    def get_client_jwks_url(self, resource_server_url: str) -> str:
+        """Return the client's published JWKS URL for the given resource server.
+
+        The authorization server fetches this URL to obtain the public key that
+        verifies the ``private_key_jwt`` client assertions this credential signs.
+        """
+        return self.identity_manager.get_client_jwks_url(resource_server_url)
+
     async def prepare_token_exchange_request(
         self,
         client: AsyncClient,

--- a/packages/oauth/tests/keycardai/oauth/server/test_credentials.py
+++ b/packages/oauth/tests/keycardai/oauth/server/test_credentials.py
@@ -164,6 +164,18 @@ class TestWebIdentity:
             assert jwks is not None
             assert len(jwks.keys) == 1
 
+    def test_get_client_jwks_url(self):
+        """WebIdentity exposes the client JWKS URL helper on the credential."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            provider = WebIdentity(
+                mcp_server_name="Test Server",
+                storage_dir=tmpdir,
+            )
+            assert (
+                provider.get_client_jwks_url("https://api.example.com")
+                == "https://api.example.com/.well-known/jwks.json"
+            )
+
     @pytest.mark.asyncio
     async def test_prepare_token_exchange_request(self, mock_client):
         """Test JWT client assertion generation."""


### PR DESCRIPTION
Part of #18 web-identity (ECO-39, JWKS-accessor-surface row).

Python's `WebIdentity` exposed only `get_jwks()` (the public key set); the client JWKS URL helper lived on the internal key manager, not on the credential. TS (`getClientJwksUrl`) and Go (`ClientJWKSURL`) expose it on the credential.

## Change (`keycardai-oauth`)
- Added `WebIdentity.get_client_jwks_url(resource_server_url)`, delegating to the key manager. Now both the public-JWKS getter and the JWKS-URL helper live on the credential, matching TS/Go (casing is idiom).

## Scope
- The other ECO-39 row (issuer/audience resolution) is a TS-side refactor tracked as a dedicated follow-up.
- Bootstrap-timing and storage-dir rows handled separately (storage-dir on the TS side; bootstrap-timing deferred as idiom).

## Tests
oauth suite green. Added a test asserting `get_client_jwks_url` returns the resource server's `/.well-known/jwks.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
