### PR TITLE
fix(keycardai-oauth): discover KEYCARD_EKS_WORKLOAD_IDENTITY_TOKEN_FILE in EKS workload identity

### DIFF
--- a/packages/oauth/src/keycardai/oauth/server/credentials.py
+++ b/packages/oauth/src/keycardai/oauth/server/credentials.py
@@ -291,6 +291,7 @@ class EKSWorkloadIdentity:
     """
 
     default_env_var_names = [
+        "KEYCARD_EKS_WORKLOAD_IDENTITY_TOKEN_FILE",
         "AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE",
         "AWS_WEB_IDENTITY_TOKEN_FILE",
     ]

--- a/packages/oauth/tests/keycardai/oauth/server/test_credentials.py
+++ b/packages/oauth/tests/keycardai/oauth/server/test_credentials.py
@@ -340,6 +340,25 @@ class TestEKSWorkloadIdentity:
                 os.environ.pop("AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE", None)
 
     @pytest.mark.asyncio
+    async def test_initialization_with_keycard_env_var(self):
+        """Test EKSWorkloadIdentity discovers KEYCARD_EKS_WORKLOAD_IDENTITY_TOKEN_FILE ahead of the AWS variables."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            keycard_file = Path(tmpdir) / "keycard-token"
+            keycard_file.write_text("eks-test-token-keycard")
+            aws_file = Path(tmpdir) / "aws-token"
+            aws_file.write_text("eks-test-token-aws")
+
+            os.environ["KEYCARD_EKS_WORKLOAD_IDENTITY_TOKEN_FILE"] = str(keycard_file)
+            os.environ["AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE"] = str(aws_file)
+            try:
+                provider = EKSWorkloadIdentity()
+                assert provider.token_file_path == str(keycard_file)
+                assert provider.env_var_name == "KEYCARD_EKS_WORKLOAD_IDENTITY_TOKEN_FILE"
+            finally:
+                os.environ.pop("KEYCARD_EKS_WORKLOAD_IDENTITY_TOKEN_FILE", None)
+                os.environ.pop("AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE", None)
+
+    @pytest.mark.asyncio
     async def test_initialization_with_custom_env_var(self):
         """Test EKSWorkloadIdentity initialization with custom environment variable."""
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
Resolves ECO-40 (eks-workload-identity spec divergence, keycard-sdk-spec #19).

`EKSWorkloadIdentity` documents `KEYCARD_EKS_WORKLOAD_IDENTITY_TOKEN_FILE` as the first env var checked during token-file discovery, but `default_env_var_names` only contained the two AWS variables, so the Keycard variable was never searched. It is now first in the list, matching the docstring and the TS and Go SDKs (both check Keycard first, then `AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE`, then `AWS_WEB_IDENTITY_TOKEN_FILE`).

Adds a test proving the Keycard variable is discovered and wins over the AWS one.

265 oauth tests pass, ruff clean. Single package scope, squash is fine.