### PR TITLE
feat(keycardai-oauth): add client_credentials_grant operation

### DIFF
--- a/packages/oauth/src/keycardai/oauth/__init__.py
+++ b/packages/oauth/src/keycardai/oauth/__init__.py
@@ -50,6 +50,7 @@ from .types.models import (
     PKCE,
     AuthorizationServerMetadata,
     ClientConfig,
+    ClientCredentialsRequest,
     ClientRegistrationRequest,
     ClientRegistrationResponse,
     Endpoints,
@@ -90,6 +91,7 @@ __all__ = [
     "Endpoints",
     "ClientConfig",
     "ClientRegistrationRequest",
+    "ClientCredentialsRequest",
     "TokenExchangeRequest",
     "AuthorizationServerMetadata",
     # === Authorization ===

--- a/packages/oauth/src/keycardai/oauth/client.py
+++ b/packages/oauth/src/keycardai/oauth/client.py
@@ -23,6 +23,10 @@ from .operations._authorize import (
     exchange_authorization_code as _exchange_authorization_code,
     exchange_authorization_code_async as _exchange_authorization_code_async,
 )
+from .operations._client_credentials import (
+    client_credentials_grant,
+    client_credentials_grant_async,
+)
 from .operations._discovery import (
     discover_server_metadata,
     discover_server_metadata_async,
@@ -38,6 +42,7 @@ from .operations._token_exchange import (
 from .types.models import (
     AuthorizationServerMetadata,
     ClientConfig,
+    ClientCredentialsRequest,
     ClientRegistrationRequest,
     ClientRegistrationResponse,
     Endpoints,
@@ -711,6 +716,72 @@ class AsyncClient:
 
         return await exchange_token_async(request, ctx)
 
+    @overload
+    async def client_credentials_grant(
+        self,
+        request: ClientCredentialsRequest,
+    ) -> TokenResponse: ...
+
+    @overload
+    async def client_credentials_grant(
+        self,
+        /,
+        *,
+        resource: str | None = None,
+        scope: str | None = None,
+        client_assertion: str | None = None,
+        client_assertion_type: str | None = None,
+        timeout: float | None = None,
+    ) -> TokenResponse: ...
+
+    async def client_credentials_grant(self, request: ClientCredentialsRequest | None = None, /, **client_credentials_args) -> TokenResponse:
+        """Perform OAuth 2.0 Client Credentials Grant.
+
+        Either pass a fully-formed ClientCredentialsRequest *or* call with
+        keyword args for common cases.
+
+        Simple usage:
+            response = await client.client_credentials_grant(
+                resource="https://api.company.com/data",
+                scope="read write"
+            )
+
+        Or with a request object:
+            request = ClientCredentialsRequest(
+                resource="https://api.company.com/data",
+                scope="read write"
+            )
+            response = await client.client_credentials_grant(request)
+
+        Args:
+            request: ClientCredentialsRequest with all grant parameters
+            **client_credentials_args: Alternative to request - provide individual parameters
+
+        Returns:
+            TokenResponse with the issued token and metadata
+
+        Raises:
+            TypeError: If both request and client_credentials_args are provided
+        """
+        if request is not None and client_credentials_args:
+            raise TypeError("Pass either `request` or keyword arguments, not both.")
+
+        if request is None:
+            request = ClientCredentialsRequest(**client_credentials_args)
+
+        endpoints = await self._get_current_endpoints()
+
+        ctx = build_http_context(
+            endpoint=endpoints.token,
+            transport=self.transport,
+            auth=self.auth_strategy,
+            user_agent=self.config.user_agent,
+            custom_headers=self.config.custom_headers,
+            timeout=client_credentials_args.get("timeout", self.config.timeout),
+        )
+
+        return await client_credentials_grant_async(request, ctx)
+
     async def exchange_authorization_code(
         self,
         *,
@@ -1290,6 +1361,72 @@ class Client:
         )
 
         return exchange_token(request, ctx)
+
+    @overload
+    def client_credentials_grant(
+        self,
+        request: ClientCredentialsRequest,
+    ) -> TokenResponse: ...
+
+    @overload
+    def client_credentials_grant(
+        self,
+        /,
+        *,
+        resource: str | None = None,
+        scope: str | None = None,
+        client_assertion: str | None = None,
+        client_assertion_type: str | None = None,
+        timeout: float | None = None,
+    ) -> TokenResponse: ...
+
+    def client_credentials_grant(self, request: ClientCredentialsRequest | None = None, /, **client_credentials_args) -> TokenResponse:
+        """Perform OAuth 2.0 Client Credentials Grant.
+
+        Either pass a fully-formed ClientCredentialsRequest *or* call with
+        keyword args for common cases.
+
+        Simple usage:
+            response = client.client_credentials_grant(
+                resource="https://api.company.com/data",
+                scope="read write"
+            )
+
+        Or with a request object:
+            request = ClientCredentialsRequest(
+                resource="https://api.company.com/data",
+                scope="read write"
+            )
+            response = client.client_credentials_grant(request)
+
+        Args:
+            request: ClientCredentialsRequest with all grant parameters
+            **client_credentials_args: Alternative to request - provide individual parameters
+
+        Returns:
+            TokenResponse with the issued token and metadata
+
+        Raises:
+            TypeError: If both request and client_credentials_args are provided
+        """
+        if request is not None and client_credentials_args:
+            raise TypeError("Pass either `request` or keyword arguments, not both.")
+
+        if request is None:
+            request = ClientCredentialsRequest(**client_credentials_args)
+
+        endpoints = self._get_current_endpoints()
+
+        ctx = build_http_context(
+            endpoint=endpoints.token,
+            transport=self.transport,
+            auth=self.auth_strategy,
+            user_agent=self.config.user_agent,
+            custom_headers=self.config.custom_headers,
+            timeout=client_credentials_args.get("timeout", self.config.timeout),
+        )
+
+        return client_credentials_grant(request, ctx)
 
     def exchange_authorization_code(
         self,

--- a/packages/oauth/src/keycardai/oauth/operations/_client_credentials.py
+++ b/packages/oauth/src/keycardai/oauth/operations/_client_credentials.py
@@ -1,0 +1,190 @@
+"""OAuth 2.0 Client Credentials Grant operations.
+
+This module implements RFC 6749 Section 4.4 Client Credentials Grant operations
+using the HTTP transport layer with byte-level operations.
+"""
+
+import json
+from urllib.parse import urlencode
+
+from ..exceptions import OAuthHttpError, OAuthProtocolError
+from ..http._context import HTTPContext
+from ..http._wire import HttpRequest, HttpResponse
+from ..types.models import ClientCredentialsRequest, TokenResponse
+
+
+def build_client_credentials_http_request(
+    request: ClientCredentialsRequest, context: HTTPContext
+) -> HttpRequest:
+    """Build HTTP request for the client credentials grant.
+
+    Args:
+        request: Client credentials grant request parameters
+        context: HTTP context with endpoint and auth strategy
+
+    Returns:
+        HttpRequest for the token endpoint
+    """
+    payload = request.model_dump(
+        mode="json",
+        exclude_none=True,
+        exclude={"timeout"}
+    )
+
+    headers = {
+        "Accept": "application/json",
+        "Content-Type": "application/x-www-form-urlencoded",
+    }
+
+    if context.auth:
+        headers.update(dict(context.auth.apply_headers()))
+
+    # Convert to properly URL-encoded form data as required by OAuth 2.0 RFC 6749
+    form_data = urlencode(payload).encode("utf-8")
+
+    return HttpRequest(
+        method="POST",
+        url=context.endpoint,
+        headers=headers,
+        body=form_data
+    )
+
+
+def parse_client_credentials_http_response(res: HttpResponse) -> TokenResponse:
+    """Parse HTTP response from the token endpoint.
+
+    Args:
+        res: HTTP response from the token endpoint
+
+    Returns:
+        TokenResponse with grant results
+
+    Raises:
+        OAuthHttpError: If HTTP error status
+        OAuthProtocolError: If invalid response format
+    """
+    if res.status >= 400:
+        full_body = res.body.decode("utf-8", "ignore")
+        try:
+            data = json.loads(full_body)
+            if isinstance(data, dict) and "error" in data:
+                raise OAuthProtocolError(
+                    error=data["error"],
+                    error_description=data.get("error_description"),
+                    error_uri=data.get("error_uri"),
+                    operation="POST /token (client_credentials)",
+                )
+        except (json.JSONDecodeError, ValueError):
+            pass
+        raise OAuthHttpError(
+            status_code=res.status,
+            response_body=full_body[:512],
+            headers=dict(res.headers),
+            operation="POST /token (client_credentials)",
+        )
+
+    try:
+        data = json.loads(res.body.decode("utf-8"))
+    except Exception as e:
+        raise OAuthProtocolError(
+            error="invalid_response",
+            error_description="Invalid JSON in client credentials response",
+            operation="POST /token (client_credentials)"
+        ) from e
+
+    if isinstance(data, dict) and "error" in data:
+        raise OAuthProtocolError(
+            error=data["error"],
+            error_description=data.get("error_description"),
+            error_uri=data.get("error_uri"),
+            operation="POST /token (client_credentials)"
+        )
+
+    if not isinstance(data, dict) or "access_token" not in data:
+        raise OAuthProtocolError(
+            error="invalid_response",
+            error_description="Missing required 'access_token' in client credentials response",
+            operation="POST /token (client_credentials)"
+        )
+
+    scope = data.get("scope")
+    if isinstance(scope, str):
+        scope = scope.split() if scope else None
+    elif isinstance(scope, list):
+        scope = scope if scope else None
+
+    return TokenResponse(
+        access_token=data["access_token"],
+        token_type=data.get("token_type", "Bearer"),
+        expires_in=data.get("expires_in"),
+        refresh_token=data.get("refresh_token"),
+        scope=scope,
+        raw=data,
+        headers=dict(res.headers),
+    )
+
+
+def client_credentials_grant(
+    request: ClientCredentialsRequest,
+    context: HTTPContext,
+) -> TokenResponse:
+    """Perform OAuth 2.0 Client Credentials Grant (sync version).
+
+    Implements RFC 6749 Section 4.4 Client Credentials Grant with graceful
+    error handling using the HTTP transport layer.
+
+    Args:
+        request: Client credentials grant request parameters
+        context: Operation context with transport and configuration
+
+    Returns:
+        TokenResponse with the issued token and metadata
+
+    Raises:
+        ValueError: If required parameters are missing
+        OAuthHttpError: If token endpoint is unreachable or returns non-200
+        OAuthProtocolError: If response format is invalid or contains OAuth errors
+        NetworkError: If network request fails
+
+    Reference: https://datatracker.ietf.org/doc/html/rfc6749#section-4.4
+    """
+    http_req = build_client_credentials_http_request(request, context)
+
+    # Execute HTTP request using transport
+    http_res = context.transport.request_raw(http_req, timeout=context.timeout)
+
+    # Parse and return token response
+    return parse_client_credentials_http_response(http_res)
+
+
+async def client_credentials_grant_async(
+    request: ClientCredentialsRequest,
+    context: HTTPContext,
+) -> TokenResponse:
+    """Perform OAuth 2.0 Client Credentials Grant (async version).
+
+    Implements RFC 6749 Section 4.4 Client Credentials Grant with graceful
+    error handling using the HTTP transport layer.
+
+    Args:
+        request: Client credentials grant request parameters
+        context: Operation context with transport and configuration
+
+    Returns:
+        TokenResponse with the issued token and metadata
+
+    Raises:
+        ValueError: If required parameters are missing
+        OAuthHttpError: If token endpoint is unreachable or returns non-200
+        OAuthProtocolError: If response format is invalid or contains OAuth errors
+        NetworkError: If network request fails
+
+    Reference: https://datatracker.ietf.org/doc/html/rfc6749#section-4.4
+    """
+    http_req = build_client_credentials_http_request(request, context)
+
+    # Execute HTTP request using async transport
+    http_res = await context.transport.request_raw(http_req, timeout=context.timeout)
+
+    # Parse and return token response
+    return parse_client_credentials_http_response(http_res)

--- a/packages/oauth/src/keycardai/oauth/types/__init__.py
+++ b/packages/oauth/src/keycardai/oauth/types/__init__.py
@@ -4,6 +4,7 @@ from .models import (
     PKCE,
     AuthorizationServerMetadata,
     ClientConfig,
+    ClientCredentialsRequest,
     ClientRegistrationRequest,
     ClientRegistrationResponse,
     Endpoints,
@@ -31,6 +32,7 @@ __all__ = [
     # Models
     "AuthorizationServerMetadata",
     "ClientConfig",
+    "ClientCredentialsRequest",
     "ClientRegistrationRequest",
     "ClientRegistrationResponse",
     "Endpoints",

--- a/packages/oauth/src/keycardai/oauth/types/models.py
+++ b/packages/oauth/src/keycardai/oauth/types/models.py
@@ -49,6 +49,24 @@ class TokenExchangeRequest(BaseModel):
     client_assertion: str | None = None
 
 
+# =============================================================================
+# Client Credentials Grant (RFC 6749 Section 4.4)
+# =============================================================================
+
+class ClientCredentialsRequest(BaseModel):
+    """OAuth 2.0 Client Credentials Grant Request as defined in RFC 6749 Section 4.4.
+
+    Reference: https://datatracker.ietf.org/doc/html/rfc6749#section-4.4
+    """
+
+    grant_type: str = "client_credentials"
+    resource: str | None = Field(default=None, description="The target resource for the requested token.")
+    scope: str | None = Field(default=None, description="Space-delimited scope of the access request.")
+    client_assertion: str | None = None
+    client_assertion_type: str | None = None
+    timeout: float | None = None
+
+
 @dataclass
 class TokenResponse:
     """RFC 8693 Token Exchange Response + RFC 6749 Token Response.

--- a/packages/oauth/tests/keycardai/oauth/operations/test_client_credentials.py
+++ b/packages/oauth/tests/keycardai/oauth/operations/test_client_credentials.py
@@ -1,0 +1,206 @@
+"""Unit tests for OAuth 2.0 Client Credentials Grant operations (RFC 6749 Section 4.4)."""
+
+from unittest.mock import AsyncMock, Mock
+from urllib.parse import parse_qs
+
+import pytest
+
+from keycardai.oauth.exceptions import OAuthHttpError, OAuthProtocolError
+from keycardai.oauth.http._context import HTTPContext
+from keycardai.oauth.http._wire import HttpResponse
+from keycardai.oauth.http.auth import BasicAuth, NoneAuth
+from keycardai.oauth.operations._client_credentials import (
+    build_client_credentials_http_request,
+    client_credentials_grant,
+    client_credentials_grant_async,
+    parse_client_credentials_http_response,
+)
+from keycardai.oauth.types.models import ClientCredentialsRequest, TokenResponse
+
+
+class TestClientCredentialsOperations:
+    """Test client credentials operation functions directly."""
+
+    def test_build_client_credentials_http_request_minimal(self):
+        """Test building minimal client credentials HTTP request."""
+        req = ClientCredentialsRequest()
+        auth = BasicAuth("client", "secret")
+
+        http_req = build_client_credentials_http_request(req, HTTPContext(endpoint="https://auth.example.com/token", transport=Mock(), auth=auth))
+
+        assert http_req.method == "POST"
+        assert http_req.url == "https://auth.example.com/token"
+        assert http_req.headers["Content-Type"] == "application/x-www-form-urlencoded"
+        assert http_req.headers["Authorization"] == "Basic Y2xpZW50OnNlY3JldA=="
+
+        form = parse_qs(http_req.body.decode("utf-8"))
+        assert form == {"grant_type": ["client_credentials"]}
+
+    def test_build_client_credentials_http_request_full(self):
+        """Test building full client credentials HTTP request."""
+        req = ClientCredentialsRequest(
+            resource="https://api.example.com",
+            scope="read write",
+            client_assertion="assertion_jwt",
+            client_assertion_type="urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+        )
+        auth = NoneAuth()
+
+        http_req = build_client_credentials_http_request(req, HTTPContext(endpoint="https://auth.example.com/token", transport=Mock(), auth=auth))
+
+        form = parse_qs(http_req.body.decode("utf-8"))
+        assert form == {
+            "grant_type": ["client_credentials"],
+            "resource": ["https://api.example.com"],
+            "scope": ["read write"],
+            "client_assertion": ["assertion_jwt"],
+            "client_assertion_type": ["urn:ietf:params:oauth:client-assertion-type:jwt-bearer"],
+        }
+
+    def test_parse_client_credentials_http_response_success(self):
+        """Test parsing successful client credentials response."""
+        response_body = b'''{
+            "access_token": "issued_access_token_123",
+            "token_type": "Bearer",
+            "expires_in": 3600,
+            "scope": "read write"
+        }'''
+
+        http_response = HttpResponse(
+            status=200,
+            headers={"Content-Type": "application/json"},
+            body=response_body
+        )
+
+        result = parse_client_credentials_http_response(http_response)
+
+        assert isinstance(result, TokenResponse)
+        assert result.access_token == "issued_access_token_123"
+        assert result.token_type == "Bearer"
+        assert result.expires_in == 3600
+        assert " ".join(result.scope) == "read write"  # scope is parsed as a list
+
+    def test_parse_client_credentials_http_response_token_type_default(self):
+        """Test token_type defaults to Bearer when omitted."""
+        http_response = HttpResponse(
+            status=200,
+            headers={"Content-Type": "application/json"},
+            body=b'{"access_token": "issued_access_token_123"}'
+        )
+
+        result = parse_client_credentials_http_response(http_response)
+
+        assert result.token_type == "Bearer"
+
+    def test_parse_client_credentials_http_response_oauth_error(self):
+        """Test parsing HTTP error response with structured OAuth error body."""
+        http_response = HttpResponse(
+            status=400,
+            headers={"Content-Type": "application/json"},
+            body=b'{"error": "invalid_scope", "error_description": "Unknown scope"}'
+        )
+
+        with pytest.raises(OAuthProtocolError, match="invalid_scope") as exc_info:
+            parse_client_credentials_http_response(http_response)
+
+        assert exc_info.value.error == "invalid_scope"
+        assert exc_info.value.error_description == "Unknown scope"
+
+    def test_parse_client_credentials_http_response_http_error_non_json(self):
+        """Test parsing HTTP error response with non-JSON body."""
+        http_response = HttpResponse(
+            status=500,
+            headers={"Content-Type": "text/plain"},
+            body=b"Internal Server Error"
+        )
+
+        with pytest.raises(OAuthHttpError, match="HTTP 500"):
+            parse_client_credentials_http_response(http_response)
+
+    def test_parse_client_credentials_http_response_invalid_json(self):
+        """Test parsing invalid JSON response."""
+        http_response = HttpResponse(
+            status=200,
+            headers={"Content-Type": "application/json"},
+            body=b"invalid json {"
+        )
+
+        with pytest.raises(OAuthProtocolError, match="Invalid JSON"):
+            parse_client_credentials_http_response(http_response)
+
+    def test_parse_client_credentials_http_response_missing_access_token(self):
+        """Test parsing response missing the required access_token field."""
+        http_response = HttpResponse(
+            status=200,
+            headers={"Content-Type": "application/json"},
+            body=b'{"token_type": "Bearer"}'
+        )
+
+        with pytest.raises(OAuthProtocolError, match="access_token") as exc_info:
+            parse_client_credentials_http_response(http_response)
+
+        assert exc_info.value.error == "invalid_response"
+
+    def test_client_credentials_grant_sync(self):
+        """Test synchronous client credentials grant."""
+        mock_transport = Mock()
+        mock_transport.request_raw.return_value = HttpResponse(
+            status=200,
+            headers={"Content-Type": "application/json"},
+            body=b'{"access_token": "sync_issued_token", "token_type": "Bearer", "expires_in": 3600}'
+        )
+
+        context = HTTPContext(
+            endpoint="https://auth.example.com/token",
+            transport=mock_transport,
+            auth=BasicAuth("client", "secret"),
+            timeout=30.0
+        )
+
+        req = ClientCredentialsRequest(scope="read")
+
+        result = client_credentials_grant(req, context)
+
+        assert isinstance(result, TokenResponse)
+        assert result.access_token == "sync_issued_token"
+        assert result.token_type == "Bearer"
+        assert result.expires_in == 3600
+
+        sent_request = mock_transport.request_raw.call_args[0][0]
+        assert sent_request.headers["Authorization"] == "Basic Y2xpZW50OnNlY3JldA=="
+        form = parse_qs(sent_request.body.decode("utf-8"))
+        assert form == {"grant_type": ["client_credentials"], "scope": ["read"]}
+
+    @pytest.mark.asyncio
+    async def test_client_credentials_grant_async(self):
+        """Test asynchronous client credentials grant."""
+        mock_transport = AsyncMock()
+        mock_transport.request_raw.return_value = HttpResponse(
+            status=200,
+            headers={"Content-Type": "application/json"},
+            body=b'{"access_token": "async_issued_token", "token_type": "Bearer", "expires_in": 7200}'
+        )
+
+        context = HTTPContext(
+            endpoint="https://auth.example.com/token",
+            transport=mock_transport,
+            auth=BasicAuth("client", "secret"),
+            timeout=30.0
+        )
+
+        req = ClientCredentialsRequest(resource="https://api.example.com")
+
+        result = await client_credentials_grant_async(req, context)
+
+        assert isinstance(result, TokenResponse)
+        assert result.access_token == "async_issued_token"
+        assert result.token_type == "Bearer"
+        assert result.expires_in == 7200
+
+        sent_request = mock_transport.request_raw.call_args[0][0]
+        assert sent_request.headers["Authorization"] == "Basic Y2xpZW50OnNlY3JldA=="
+        form = parse_qs(sent_request.body.decode("utf-8"))
+        assert form == {
+            "grant_type": ["client_credentials"],
+            "resource": ["https://api.example.com"],
+        }

--- a/packages/oauth/tests/keycardai/oauth/test_client.py
+++ b/packages/oauth/tests/keycardai/oauth/test_client.py
@@ -9,6 +9,7 @@ from keycardai.oauth import AsyncClient, Client, ClientConfig
 from keycardai.oauth.exceptions import ConfigError
 from keycardai.oauth.types.models import (
     AuthorizationServerMetadata,
+    ClientCredentialsRequest,
     ClientRegistrationRequest,
     ServerMetadataRequest,
     TokenExchangeRequest,
@@ -334,6 +335,70 @@ class TestOverloadEquivalence:
 
             assert dict1 == dict2, f"Async exchange token requests differ: {dict1} != {dict2}"
 
+    def test_client_credentials_grant_overload_equivalence(self):
+        """Test that client_credentials_grant overloads create equivalent calls."""
+        test_data = {
+            "resource": "https://api.company.com/data",
+            "scope": "read write",
+            "timeout": 15.0,
+        }
+
+        request_obj = ClientCredentialsRequest(**test_data)
+
+        with patch('keycardai.oauth.client.client_credentials_grant') as mock_grant:
+            mock_grant.return_value = Mock()
+            client = Client("https://test.keycard.cloud")
+
+            # Method 1: Using request object
+            client.client_credentials_grant(request_obj)
+            call1_args = mock_grant.call_args
+
+            # Method 2: Using kwargs
+            mock_grant.reset_mock()
+            client.client_credentials_grant(**test_data)
+            call2_args = mock_grant.call_args
+
+            # Compare the requests
+            request1 = call1_args[0][0]
+            request2 = call2_args[0][0]
+
+            dict1 = request1.model_dump(exclude_none=True)
+            dict2 = request2.model_dump(exclude_none=True)
+
+            assert dict1 == dict2, f"Client credentials requests differ: {dict1} != {dict2}"
+
+    @pytest.mark.asyncio
+    async def test_async_client_credentials_grant_overload_equivalence(self):
+        """Test that async client_credentials_grant overloads create equivalent calls."""
+        test_data = {
+            "resource": "https://api.company.com/data",
+            "scope": "read write",
+        }
+
+        request_obj = ClientCredentialsRequest(**test_data)
+
+        with patch('keycardai.oauth.client.client_credentials_grant_async') as mock_grant_async:
+            mock_grant_async.return_value = Mock()
+            async_client = AsyncClient("https://test.keycard.cloud")
+
+            # Method 1: Using request object
+            await async_client.client_credentials_grant(request_obj)
+            call1_args = mock_grant_async.call_args
+
+            # Method 2: Using kwargs
+            mock_grant_async.reset_mock()
+            await async_client.client_credentials_grant(**test_data)
+            call2_args = mock_grant_async.call_args
+
+            # Compare the requests
+            request1 = call1_args[0][0]
+            request2 = call2_args[0][0]
+
+            dict1 = request1.model_dump(exclude_none=True)
+            dict2 = request2.model_dump(exclude_none=True)
+
+            assert dict1 == dict2, f"Async client credentials requests differ: {dict1} != {dict2}"
+
     def test_discover_server_metadata_overload_equivalence(self):
         """Test that discover_server_metadata overloads create equivalent calls."""
         test_base_url = "https://custom.auth.server.com"
@@ -406,6 +471,11 @@ class TestOverloadEquivalence:
         with pytest.raises(TypeError, match="both"):
             client.exchange_token(request, subject_token="another")
 
+        # Test client_credentials_grant error handling
+        request = ClientCredentialsRequest(scope="read")
+        with pytest.raises(TypeError, match="both"):
+            client.client_credentials_grant(request, scope="write")
+
         # Test discover_server_metadata error handling
         request = ServerMetadataRequest(base_url="https://test.com")
         with pytest.raises(TypeError, match="both"):
@@ -428,6 +498,11 @@ class TestOverloadEquivalence:
         )
         with pytest.raises(TypeError, match="both"):
             await async_client.exchange_token(request, subject_token="another")
+
+        # Test async client_credentials_grant error handling
+        request = ClientCredentialsRequest(scope="read")
+        with pytest.raises(TypeError, match="both"):
+            await async_client.client_credentials_grant(request, scope="write")
 
         # Test async discover_server_metadata error handling
         request = ServerMetadataRequest(base_url="https://test.com")


### PR DESCRIPTION
Part of ECO-43 (client-credentials spec, keycard-sdk-spec #22): adds a first-class RFC 6749 section 4.4 client credentials grant. Previously only the Go SDK implemented the grant; the companion TS PR is typescript-sdk#83.

Host surface follows the Python idiom (operation on the general client, like `exchange_token` / `register_client`):

- New `ClientCredentialsRequest` model: `resource`, `scope`, `client_assertion`, `client_assertion_type` (all optional), `grant_type` defaulting to `client_credentials`.
- New `operations/_client_credentials.py` mirroring the token-exchange transport contract (form POST, OAuth error JSON -> `OAuthProtocolError`, HTTP errors -> `OAuthHttpError`, missing `access_token` -> `invalid_response`, `token_type` default `Bearer`).
- `client_credentials_grant` on both `Client` and `AsyncClient`: request object or keyword arguments, client auth via the configured credential (Basic), token endpoint from discovery.

277 oauth tests pass (20 new), ruff clean. Single package scope, squash is fine.