### PR TITLE
feat(keycardai-starlette)!: align metadata endpoints with the RFC 9728 contract

### DIFF
--- a/packages/mcp/tests/integration/test_metadata.py
+++ b/packages/mcp/tests/integration/test_metadata.py
@@ -5,6 +5,7 @@ from the OAuth metadata endpoints.
 """
 
 from unittest.mock import Mock, patch
+from urllib.parse import quote
 
 import pytest
 from starlette.applications import Starlette
@@ -59,37 +60,40 @@ class TestProtectedResourceMetadata:
         assert "resource" in data
         assert "testserver" in data["resource"]
 
-    def test_contains_jwks_uri(self, client):
-        """Test that response contains jwks_uri field."""
+    def test_omits_jwks_uri_when_no_jwks_configured(self, client):
+        """Test that jwks_uri is absent when no JWKS is configured."""
         response = client.get("/.well-known/oauth-protected-resource")
         data = response.json()
 
-        assert "jwks_uri" in data
-        assert "/.well-known/jwks.json" in data["jwks_uri"]
+        assert "jwks_uri" not in data
 
-    def test_contains_client_id(self, client):
-        """Test that response contains client_id matching resource."""
+    def test_omits_client_id(self, client):
+        """Test that the document does not contain client_id."""
         response = client.get("/.well-known/oauth-protected-resource")
         data = response.json()
 
-        assert "client_id" in data
-        assert data["client_id"] == data["resource"]
+        assert "client_id" not in data
 
-    def test_contains_grant_types(self, client):
-        """Test that response contains grant_types with client_credentials."""
+    def test_omits_grant_types(self, client):
+        """Test that the document does not contain grant_types."""
         response = client.get("/.well-known/oauth-protected-resource")
         data = response.json()
 
-        assert "grant_types" in data
-        assert "client_credentials" in data["grant_types"]
+        assert "grant_types" not in data
 
-    def test_contains_token_endpoint_auth_method(self, client):
-        """Test that token_endpoint_auth_method is private_key_jwt."""
+    def test_omits_client_name(self, client):
+        """Test that the document does not contain client_name."""
         response = client.get("/.well-known/oauth-protected-resource")
         data = response.json()
 
-        assert "token_endpoint_auth_method" in data
-        assert data["token_endpoint_auth_method"] == "private_key_jwt"
+        assert "client_name" not in data
+
+    def test_omits_token_endpoint_auth_method(self, client):
+        """Test that the document does not contain token_endpoint_auth_method."""
+        response = client.get("/.well-known/oauth-protected-resource")
+        data = response.json()
+
+        assert "token_endpoint_auth_method" not in data
 
 
 class TestAuthorizationServerMetadata:
@@ -155,7 +159,9 @@ class TestAuthorizationServerMetadata:
         data = response.json()
 
         assert data["issuer"] == issuer
-        assert data["authorization_endpoint"] == f"{issuer}/oauth/authorize"
+        assert data["authorization_endpoint"] == (
+            f"{issuer}/oauth/authorize?resource={quote('http://testserver', safe='')}"
+        )
         assert data["token_endpoint"] == f"{issuer}/oauth/token"
 
     @patch("httpx.Client")
@@ -329,6 +335,14 @@ class TestAuthMetadataMount:
 
         assert data["keys"][0]["kid"] == "mount-test-key"
 
+    def test_protected_resource_contains_jwks_uri(self, client):
+        """Test that jwks_uri is advertised when a JWKS is configured."""
+        response = client.get("/.well-known/oauth-protected-resource")
+        data = response.json()
+
+        assert "jwks_uri" in data
+        assert "/.well-known/jwks.json" in data["jwks_uri"]
+
     def test_protected_resource_has_correct_issuer(self, issuer, client):
         """Test that protected resource points to correct authorization server."""
         response = client.get("/.well-known/oauth-protected-resource")
@@ -396,14 +410,12 @@ class TestDynamicResourcePaths:
             "The full path suffix should be reflected in the resource URL."
         )
 
-    def test_protected_resource_client_id_matches_resource(self, client):
-        """Test that client_id matches the resource URL including path suffix."""
+    def test_protected_resource_omits_client_id(self, client):
+        """Test that the document does not contain client_id for suffixed paths."""
         response = client.get("/.well-known/oauth-protected-resource/my-service")
         data = response.json()
 
-        assert data["client_id"] == data["resource"], (
-            "client_id should equal resource URL including the path suffix."
-        )
+        assert "client_id" not in data
 
     def test_base_path_still_works(self, client):
         """Test that the base path without suffix still works."""

--- a/packages/mcp/tests/keycardai/mcp/server/handlers/test_metadata.py
+++ b/packages/mcp/tests/keycardai/mcp/server/handlers/test_metadata.py
@@ -5,6 +5,7 @@ These tests focus on URL handling and slash character edge cases.
 
 import json
 from unittest.mock import Mock, patch
+from urllib.parse import quote
 
 import httpx
 import pytest
@@ -533,9 +534,11 @@ class TestAuthorizationServerMetadata:
         assert response.status_code == 200
         response_data = json.loads(response.body)
 
-        # The authorization_endpoint should be exactly as returned by the upstream server
-        # without any base_url prepending
-        assert response_data["authorization_endpoint"] == "https://auth.example.com/oauth/authorize"
+        # The authorization_endpoint carries a resource parameter pointing at
+        # this resource server's origin
+        assert response_data["authorization_endpoint"] == (
+            f"https://auth.example.com/oauth/authorize?resource={quote('https://example.com', safe='')}"
+        )
         assert response_data["token_endpoint"] == "https://auth.example.com/oauth/token"
         assert response_data["issuer"] == "https://auth.example.com"
 
@@ -570,8 +573,11 @@ class TestAuthorizationServerMetadata:
         assert response.status_code == 200
         response_data = json.loads(response.body)
 
-        # The authorization_endpoint should be exactly as returned by the upstream server
-        assert response_data["authorization_endpoint"] == "https://zone123.keycard.cloud/oauth/authorize"
+        # The authorization_endpoint carries a resource parameter pointing at
+        # this resource server's origin
+        assert response_data["authorization_endpoint"] == (
+            f"https://zone123.keycard.cloud/oauth/authorize?resource={quote('https://example.com', safe='')}"
+        )
         assert response_data["token_endpoint"] == "https://zone123.keycard.cloud/oauth/token"
         assert response_data["issuer"] == "https://zone123.keycard.cloud"
 
@@ -607,7 +613,9 @@ class TestAuthorizationServerMetadata:
         response_data = json.loads(response.body)
 
         # Should use original issuer since no zone ID
-        assert response_data["authorization_endpoint"] == "https://keycard.cloud/oauth/authorize"
+        assert response_data["authorization_endpoint"] == (
+            f"https://keycard.cloud/oauth/authorize?resource={quote('https://example.com', safe='')}"
+        )
 
         # Verify the original URL was called
         mock_client.get.assert_called_once_with("https://keycard.cloud/.well-known/oauth-authorization-server")
@@ -707,7 +715,7 @@ class TestAuthorizationServerMetadata:
 
     @patch("httpx.Client")
     def test_authorization_endpoint_preservation(self, mock_client_class):
-        """Test that authorization_endpoint is preserved exactly as returned by upstream."""
+        """Test that upstream authorization_endpoint URLs gain a resource parameter."""
         # Mock response with various URL formats
         test_cases = [
             "https://auth.example.com/oauth/authorize",
@@ -735,10 +743,13 @@ class TestAuthorizationServerMetadata:
             # Execute handler
             response = handler(request)
 
-            # Verify the authorization_endpoint is preserved exactly
+            # Verify the upstream endpoint is preserved with the resource
+            # parameter appended
             assert response.status_code == 200
             response_data = json.loads(response.body)
-            assert response_data["authorization_endpoint"] == auth_endpoint
+            assert response_data["authorization_endpoint"] == (
+                f"{auth_endpoint}?resource={quote('https://example.com', safe='')}"
+            )
 
     @patch("httpx.Client")
     def test_response_json_format(self, mock_client_class):

--- a/packages/starlette/src/keycardai/starlette/handlers/jwks.py
+++ b/packages/starlette/src/keycardai/starlette/handlers/jwks.py
@@ -4,7 +4,9 @@ from collections.abc import Callable
 
 from keycardai.oauth.types import JsonWebKeySet
 from starlette.requests import Request
-from starlette.responses import JSONResponse
+from starlette.responses import JSONResponse, Response
+
+from .metadata import CORS_HEADERS, _preflight_response
 
 
 def jwks_endpoint(jwks: JsonWebKeySet) -> Callable:
@@ -17,11 +19,14 @@ def jwks_endpoint(jwks: JsonWebKeySet) -> Callable:
         Callable endpoint that serves the JWKS data
     """
 
-    def wrapper(request: Request) -> JSONResponse:
+    def wrapper(request: Request) -> Response:
+        if request.method == "OPTIONS":
+            return _preflight_response()
+
         return JSONResponse(
             content=jwks.model_dump(exclude_none=True),
             status_code=200,
-            headers={"Content-Type": "application/json"},
+            headers={"Content-Type": "application/json", **CORS_HEADERS},
         )
 
     return wrapper

--- a/packages/starlette/src/keycardai/starlette/handlers/metadata.py
+++ b/packages/starlette/src/keycardai/starlette/handlers/metadata.py
@@ -5,15 +5,27 @@ Implements RFC 9728 (OAuth Protected Resource Metadata) and RFC 8414
 """
 
 from collections.abc import Callable
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 import httpx
 from pydantic import AnyHttpUrl, BaseModel, Field
 
-from keycardai.oauth.types.oauth import GrantType, TokenEndpointAuthMethod
 from starlette.requests import Request
 from starlette.responses import JSONResponse, Response
 
 from ..shared.starlette import get_base_url
+
+CORS_HEADERS = {"Access-Control-Allow-Origin": "*"}
+
+PREFLIGHT_HEADERS = {
+    "Access-Control-Allow-Origin": "*",
+    "Access-Control-Allow-Methods": "GET, OPTIONS",
+    "Access-Control-Allow-Headers": "Content-Type, MCP-Protocol-Version",
+}
+
+
+def _preflight_response() -> Response:
+    return Response(status_code=204, headers=PREFLIGHT_HEADERS)
 
 
 class ProtectedResourceMetadata(BaseModel):
@@ -35,14 +47,7 @@ class ProtectedResourceMetadata(BaseModel):
     resource_documentation: AnyHttpUrl | None = None
     resource_policy_uri: AnyHttpUrl | None = None
     resource_tos_uri: AnyHttpUrl | None = None
-    # Extended fields for OAuth client registration context
-    client_id: str | None = Field(default=None)
-    client_name: str | None = Field(default=None)
     redirect_uris: list[AnyHttpUrl] | None = Field(default=None)
-    token_endpoint_auth_method: TokenEndpointAuthMethod | None = Field(
-        default=None
-    )
-    grant_types: list[GrantType] | None = Field(default=None)
 
 
 # ---------------------------------------------------------------------------
@@ -109,10 +114,23 @@ def _remove_authorization_server_prefix(path: str) -> str:
 def protected_resource_metadata(
     metadata: ProtectedResourceMetadata,
     enable_multi_zone: bool = False,
+    include_jwks_uri: bool = True,
 ) -> Callable:
-    """Create a Starlette handler that serves OAuth Protected Resource Metadata (RFC 9728)."""
+    """Create a Starlette handler that serves OAuth Protected Resource Metadata (RFC 9728).
+
+    Args:
+        metadata: Base metadata document; per-request fields (``resource``,
+            ``jwks_uri``) are derived from the incoming request.
+        enable_multi_zone: When True, rewrite the authorization server host
+            with the zone id taken from the request path.
+        include_jwks_uri: When True, advertise a ``jwks_uri`` pointing at the
+            server's ``/.well-known/jwks.json`` endpoint.
+    """
 
     def wrapper(request: Request) -> Response:
+        if request.method == "OPTIONS":
+            return _preflight_response()
+
         request_metadata = metadata.model_copy(deep=True)
         path = _remove_well_known_prefix(request.url.path)
 
@@ -128,28 +146,50 @@ def protected_resource_metadata(
                 ]
 
         request_metadata.resource = _create_resource_url(base_url, path)
-        request_metadata.jwks_uri = _create_jwks_uri(base_url)
-        request_metadata.client_id = str(request_metadata.resource)
-        request_metadata.client_name = "OAuth Resource Server"
-        request_metadata.token_endpoint_auth_method = (
-            TokenEndpointAuthMethod.PRIVATE_KEY_JWT
-        )
-        request_metadata.grant_types = [GrantType.CLIENT_CREDENTIALS]
+        if include_jwks_uri:
+            request_metadata.jwks_uri = _create_jwks_uri(base_url)
 
         return JSONResponse(
             content=request_metadata.model_dump(mode="json", exclude_none=True),
+            headers=CORS_HEADERS,
         )
 
     return wrapper
 
 
+def _append_resource_param(endpoint: str, resource: str) -> str:
+    """Append a ``resource`` query parameter to an endpoint URL.
+
+    Existing query parameters are preserved.
+    """
+    parts = urlsplit(endpoint)
+    query = parse_qsl(parts.query, keep_blank_values=True)
+    query.append(("resource", resource))
+    return urlunsplit(parts._replace(query=urlencode(query)))
+
+
 def authorization_server_metadata(
     issuer: str,
     enable_multi_zone: bool = False,
+    timeout: float = 10.0,
 ) -> Callable:
-    """Create a Starlette handler that proxies OAuth Authorization Server Metadata (RFC 8414)."""
+    """Create a Starlette handler that proxies OAuth Authorization Server Metadata (RFC 8414).
+
+    The upstream document's ``authorization_endpoint``, when present, gains a
+    ``resource`` query parameter set to this resource server's origin so the
+    authorization server can associate the request with this resource.
+
+    Args:
+        issuer: Authorization server issuer URL to proxy metadata from.
+        enable_multi_zone: When True, rewrite the issuer host with the zone id
+            taken from the request path.
+        timeout: Timeout in seconds for the upstream metadata fetch.
+    """
 
     def wrapper(request: Request) -> Response:
+        if request.method == "OPTIONS":
+            return _preflight_response()
+
         actual_issuer = issuer
         try:
             path = _remove_authorization_server_prefix(request.url.path)
@@ -167,12 +207,20 @@ def authorization_server_metadata(
             # Explicit timeout so a slow upstream cannot pin a Starlette threadpool
             # worker indefinitely. Sync httpx.Client is fine here because Starlette
             # dispatches sync handlers to a threadpool, not the event loop.
-            with httpx.Client(timeout=httpx.Timeout(5.0)) as client:
+            with httpx.Client(timeout=httpx.Timeout(timeout)) as client:
                 resp = client.get(
                     f"{issuer_url}/.well-known/oauth-authorization-server"
                 )
                 resp.raise_for_status()
-                return JSONResponse(content=resp.json())
+                content = resp.json()
+                if isinstance(content, dict) and content.get(
+                    "authorization_endpoint"
+                ):
+                    content["authorization_endpoint"] = _append_resource_param(
+                        content["authorization_endpoint"],
+                        get_base_url(request),
+                    )
+                return JSONResponse(content=content, headers=CORS_HEADERS)
         except httpx.HTTPStatusError as e:
             return JSONResponse(
                 content={

--- a/packages/starlette/src/keycardai/starlette/routers/metadata.py
+++ b/packages/starlette/src/keycardai/starlette/routers/metadata.py
@@ -29,14 +29,37 @@ def auth_metadata_mount(
     issuer: str,
     enable_multi_zone: bool = False,
     jwks: JsonWebKeySet | None = None,
+    scopes_supported: list[str] | None = None,
+    resource_name: str | None = None,
+    resource_documentation: str | None = None,
+    as_metadata_timeout: float = 10.0,
 ) -> Mount:
-    """Create a Starlette Mount for OAuth metadata endpoints at ``/.well-known``."""
+    """Create a Starlette Mount for OAuth metadata endpoints at ``/.well-known``.
+
+    Args:
+        issuer: OAuth issuer URL for metadata endpoints.
+        enable_multi_zone: When True, derive a zone-scoped authorization
+            server from the request path.
+        jwks: Optional JWKS to expose at ``/.well-known/jwks.json``.
+        scopes_supported: Optional scope values advertised in the protected
+            resource metadata document.
+        resource_name: Optional human-readable resource name advertised in
+            the protected resource metadata document.
+        resource_documentation: Optional documentation URL advertised in the
+            protected resource metadata document.
+        as_metadata_timeout: Timeout in seconds for the upstream
+            authorization server metadata fetch.
+    """
     return well_known_metadata_mount(
         path="/.well-known",
         issuer=issuer,
         resource="{resource_path:path}",
         enable_multi_zone=enable_multi_zone,
         jwks=jwks,
+        scopes_supported=scopes_supported,
+        resource_name=resource_name,
+        resource_documentation=resource_documentation,
+        as_metadata_timeout=as_metadata_timeout,
     )
 
 
@@ -46,6 +69,10 @@ def well_known_metadata_mount(
     resource: str = "",
     enable_multi_zone: bool = False,
     jwks: JsonWebKeySet | None = None,
+    scopes_supported: list[str] | None = None,
+    resource_name: str | None = None,
+    resource_documentation: str | None = None,
+    as_metadata_timeout: float = 10.0,
 ) -> Mount:
     """Create a Starlette Mount for OAuth metadata endpoints at a custom path."""
     return Mount(
@@ -55,6 +82,10 @@ def well_known_metadata_mount(
             enable_multi_zone=enable_multi_zone,
             jwks=jwks,
             resource=resource,
+            scopes_supported=scopes_supported,
+            resource_name=resource_name,
+            resource_documentation=resource_documentation,
+            as_metadata_timeout=as_metadata_timeout,
         ),
     )
 
@@ -64,6 +95,10 @@ def well_known_metadata_routes(
     enable_multi_zone: bool = False,
     jwks: JsonWebKeySet | None = None,
     resource: str = "",
+    scopes_supported: list[str] | None = None,
+    resource_name: str | None = None,
+    resource_documentation: str | None = None,
+    as_metadata_timeout: float = 10.0,
 ) -> list[Route]:
     """Create Starlette Routes for OAuth well-known metadata endpoints."""
     protected_resource_path = (
@@ -79,28 +114,42 @@ def well_known_metadata_routes(
 
     metadata = ProtectedResourceMetadata(
         authorization_servers=[issuer],
+        scopes_supported=scopes_supported,
+        resource_name=resource_name,
+        resource_documentation=resource_documentation,
     )
 
     routes = [
         Route(
             protected_resource_path,
             protected_resource_metadata(
-                metadata, enable_multi_zone=enable_multi_zone
+                metadata,
+                enable_multi_zone=enable_multi_zone,
+                include_jwks_uri=jwks is not None,
             ),
             name="oauth-protected-resource",
+            methods=["GET", "OPTIONS"],
         ),
         Route(
             auth_server_path,
             authorization_server_metadata(
-                issuer, enable_multi_zone=enable_multi_zone
+                issuer,
+                enable_multi_zone=enable_multi_zone,
+                timeout=as_metadata_timeout,
             ),
             name="oauth-authorization-server",
+            methods=["GET", "OPTIONS"],
         ),
     ]
 
     if jwks:
         routes.append(
-            Route("/jwks.json", jwks_endpoint(jwks), name="jwks")
+            Route(
+                "/jwks.json",
+                jwks_endpoint(jwks),
+                name="jwks",
+                methods=["GET", "OPTIONS"],
+            )
         )
 
     return routes
@@ -110,17 +159,27 @@ def well_known_protected_resource_route(
     issuer: str,
     enable_multi_zone: bool = False,
     resource: str = "/oauth-protected-resource",
+    scopes_supported: list[str] | None = None,
+    resource_name: str | None = None,
+    resource_documentation: str | None = None,
+    include_jwks_uri: bool = True,
 ) -> Route:
     """Create a Starlette Route for the OAuth Protected Resource Metadata endpoint (RFC 9728)."""
     metadata = ProtectedResourceMetadata(
         authorization_servers=[issuer],
+        scopes_supported=scopes_supported,
+        resource_name=resource_name,
+        resource_documentation=resource_documentation,
     )
     return Route(
         resource,
         protected_resource_metadata(
-            metadata, enable_multi_zone=enable_multi_zone
+            metadata,
+            enable_multi_zone=enable_multi_zone,
+            include_jwks_uri=include_jwks_uri,
         ),
         name="oauth-protected-resource",
+        methods=["GET", "OPTIONS"],
     )
 
 
@@ -128,20 +187,26 @@ def well_known_authorization_server_route(
     issuer: str,
     enable_multi_zone: bool = False,
     resource: str = "/oauth-authorization-server",
+    as_metadata_timeout: float = 10.0,
 ) -> Route:
     """Create a Starlette Route for the OAuth Authorization Server Metadata endpoint (RFC 8414)."""
     return Route(
         resource,
         authorization_server_metadata(
-            issuer, enable_multi_zone=enable_multi_zone
+            issuer,
+            enable_multi_zone=enable_multi_zone,
+            timeout=as_metadata_timeout,
         ),
         name="oauth-authorization-server",
+        methods=["GET", "OPTIONS"],
     )
 
 
 def well_known_jwks_route(jwks: JsonWebKeySet) -> Route:
     """Create a Starlette Route for the JSON Web Key Set (JWKS) endpoint."""
-    return Route("/jwks.json", jwks_endpoint(jwks), name="jwks")
+    return Route(
+        "/jwks.json", jwks_endpoint(jwks), name="jwks", methods=["GET", "OPTIONS"]
+    )
 
 
 def protected_router(
@@ -151,6 +216,10 @@ def protected_router(
     enable_multi_zone: bool = False,
     jwks: JsonWebKeySet | None = None,
     require_authentication: bool = False,
+    scopes_supported: list[str] | None = None,
+    resource_name: str | None = None,
+    resource_documentation: str | None = None,
+    as_metadata_timeout: float = 10.0,
 ) -> Sequence[Route]:
     """Create a protected router with OAuth metadata and bearer auth middleware.
 
@@ -170,6 +239,14 @@ def protected_router(
             sub-apps (e.g. an MCP JSONRPC dispatcher) that have no per-route
             ``@requires("authenticated")`` gate of their own. Defaults to False
             to preserve the mixed-route behavior.
+        scopes_supported: Optional scope values advertised in the protected
+            resource metadata document.
+        resource_name: Optional human-readable resource name advertised in
+            the protected resource metadata document.
+        resource_documentation: Optional documentation URL advertised in the
+            protected resource metadata document.
+        as_metadata_timeout: Timeout in seconds for the upstream
+            authorization server metadata fetch.
 
     Returns:
         Sequence of routes including metadata mount and protected app mount.
@@ -189,7 +266,13 @@ def protected_router(
     """
     routes: list[Mount | Route] = [
         auth_metadata_mount(
-            issuer, enable_multi_zone=enable_multi_zone, jwks=jwks
+            issuer,
+            enable_multi_zone=enable_multi_zone,
+            jwks=jwks,
+            scopes_supported=scopes_supported,
+            resource_name=resource_name,
+            resource_documentation=resource_documentation,
+            as_metadata_timeout=as_metadata_timeout,
         ),
     ]
 

--- a/packages/starlette/tests/keycardai/starlette/test_routers.py
+++ b/packages/starlette/tests/keycardai/starlette/test_routers.py
@@ -6,6 +6,7 @@ RFC 9728 / RFC 8414 discovery endpoints.
 
 from unittest.mock import Mock, patch
 
+import httpx
 import pytest
 from starlette.applications import Starlette
 from starlette.responses import PlainTextResponse
@@ -37,6 +38,22 @@ def client(app):
     return TestClient(app)
 
 
+@pytest.fixture
+def sample_jwks():
+    return JsonWebKeySet(
+        keys=[
+            JsonWebKey(
+                kty="RSA",
+                kid="test-key-1",
+                use="sig",
+                alg="RS256",
+                n="test-modulus",
+                e="AQAB",
+            )
+        ]
+    )
+
+
 class TestProtectedResourceMetadata:
     def test_returns_200(self, client):
         response = client.get("/.well-known/oauth-protected-resource")
@@ -57,29 +74,86 @@ class TestProtectedResourceMetadata:
         response = client.get("/.well-known/oauth-protected-resource")
         assert "testserver" in response.json()["resource"]
 
-    def test_contains_jwks_uri(self, client):
-        response = client.get("/.well-known/oauth-protected-resource")
+    def test_contains_jwks_uri_when_jwks_supplied(self, issuer, sample_jwks):
+        app = Starlette(
+            routes=[
+                well_known_metadata_mount(
+                    issuer=issuer, path="/.well-known", jwks=sample_jwks
+                )
+            ]
+        )
+        response = TestClient(app).get("/.well-known/oauth-protected-resource")
         assert "/.well-known/jwks.json" in response.json()["jwks_uri"]
 
-    def test_contains_client_id(self, client):
+    def test_omits_jwks_uri_without_jwks(self, client):
         data = client.get("/.well-known/oauth-protected-resource").json()
-        assert data["client_id"] == data["resource"]
+        assert "jwks_uri" not in data
 
-    def test_contains_grant_types(self, client):
+    def test_omits_client_registration_fields(self, client):
         data = client.get("/.well-known/oauth-protected-resource").json()
-        assert "client_credentials" in data["grant_types"]
+        for field in (
+            "client_id",
+            "client_name",
+            "token_endpoint_auth_method",
+            "grant_types",
+        ):
+            assert field not in data
+
+    def test_contains_bearer_methods_supported(self, client):
+        data = client.get("/.well-known/oauth-protected-resource").json()
+        assert data["bearer_methods_supported"] == ["header"]
+
+    def test_optional_resource_fields_absent_by_default(self, client):
+        data = client.get("/.well-known/oauth-protected-resource").json()
+        for field in ("scopes_supported", "resource_name", "resource_documentation"):
+            assert field not in data
+
+    def test_optional_resource_fields_emitted_when_supplied(self, issuer):
+        app = Starlette(
+            routes=[
+                well_known_metadata_mount(
+                    issuer=issuer,
+                    path="/.well-known",
+                    scopes_supported=["read", "write"],
+                    resource_name="Example Resource",
+                    resource_documentation="https://docs.example.com/",
+                )
+            ]
+        )
+        data = (
+            TestClient(app).get("/.well-known/oauth-protected-resource").json()
+        )
+        assert data["scopes_supported"] == ["read", "write"]
+        assert data["resource_name"] == "Example Resource"
+        assert data["resource_documentation"] == "https://docs.example.com/"
+
+    def test_get_has_cors_header(self, client):
+        response = client.get("/.well-known/oauth-protected-resource")
+        assert response.headers["access-control-allow-origin"] == "*"
+
+    def test_options_preflight(self, client):
+        response = client.options("/.well-known/oauth-protected-resource")
+        assert response.status_code == 204
+        assert response.headers["access-control-allow-origin"] == "*"
+        assert response.headers["access-control-allow-methods"] == "GET, OPTIONS"
+        assert (
+            response.headers["access-control-allow-headers"]
+            == "Content-Type, MCP-Protocol-Version"
+        )
+
+
+def _mock_upstream(mock_client_cls, payload):
+    mock_resp = Mock()
+    mock_resp.json.return_value = payload
+    mock_resp.raise_for_status.return_value = None
+    mock_client_cls.return_value.__enter__.return_value.get.return_value = mock_resp
 
 
 class TestAuthorizationServerMetadata:
     def test_proxies_upstream(self, client, issuer):
         upstream = {"issuer": issuer, "token_endpoint": f"{issuer}/oauth/token"}
         with patch("httpx.Client") as mock_client_cls:
-            mock_resp = Mock()
-            mock_resp.json.return_value = upstream
-            mock_resp.raise_for_status.return_value = None
-            mock_client_cls.return_value.__enter__.return_value.get.return_value = (
-                mock_resp
-            )
+            _mock_upstream(mock_client_cls, upstream)
             response = client.get("/.well-known/oauth-authorization-server")
             assert response.status_code == 200
             assert response.json()["issuer"] == issuer
@@ -94,37 +168,82 @@ class TestAuthorizationServerMetadata:
             response = client.get("/.well-known/oauth-authorization-server")
             assert response.status_code == 503
 
-    def test_explicit_timeout_passed_to_client(self, client, issuer):
-        """authorization_server_metadata must pass an explicit timeout to httpx."""
+    def test_authorization_endpoint_gains_resource_param(self, client, issuer):
+        upstream = {
+            "issuer": issuer,
+            "authorization_endpoint": f"{issuer}/oauth/authorize",
+        }
         with patch("httpx.Client") as mock_client_cls:
-            mock_resp = Mock()
-            mock_resp.json.return_value = {"issuer": issuer}
-            mock_resp.raise_for_status.return_value = None
-            mock_client_cls.return_value.__enter__.return_value.get.return_value = (
-                mock_resp
+            _mock_upstream(mock_client_cls, upstream)
+            data = client.get("/.well-known/oauth-authorization-server").json()
+            assert (
+                data["authorization_endpoint"]
+                == f"{issuer}/oauth/authorize?resource=http%3A%2F%2Ftestserver"
             )
+
+    def test_authorization_endpoint_preserves_existing_query(self, client, issuer):
+        upstream = {
+            "issuer": issuer,
+            "authorization_endpoint": f"{issuer}/oauth/authorize?audience=abc",
+        }
+        with patch("httpx.Client") as mock_client_cls:
+            _mock_upstream(mock_client_cls, upstream)
+            data = client.get("/.well-known/oauth-authorization-server").json()
+            assert (
+                data["authorization_endpoint"]
+                == f"{issuer}/oauth/authorize?audience=abc&resource=http%3A%2F%2Ftestserver"
+            )
+
+    def test_no_authorization_endpoint_left_unchanged(self, client, issuer):
+        upstream = {"issuer": issuer}
+        with patch("httpx.Client") as mock_client_cls:
+            _mock_upstream(mock_client_cls, upstream)
+            data = client.get("/.well-known/oauth-authorization-server").json()
+            assert "authorization_endpoint" not in data
+
+    def test_default_timeout_passed_to_client(self, client, issuer):
+        with patch("httpx.Client") as mock_client_cls:
+            _mock_upstream(mock_client_cls, {"issuer": issuer})
             client.get("/.well-known/oauth-authorization-server")
             call_kwargs = mock_client_cls.call_args.kwargs
             assert "timeout" in call_kwargs, (
                 "httpx.Client must be constructed with explicit timeout to "
                 "avoid pinning a threadpool worker indefinitely."
             )
+            assert call_kwargs["timeout"] == httpx.Timeout(10.0)
 
-
-class TestJwksEndpoint:
-    def test_returns_jwks_when_provided(self, issuer):
-        jwks = JsonWebKeySet(
-            keys=[
-                JsonWebKey(
-                    kty="RSA",
-                    kid="test-key-1",
-                    use="sig",
-                    alg="RS256",
-                    n="test-modulus",
-                    e="AQAB",
+    def test_custom_timeout_passed_to_client(self, issuer):
+        app = Starlette(
+            routes=[
+                well_known_metadata_mount(
+                    issuer=issuer, path="/.well-known", as_metadata_timeout=2.5
                 )
             ]
         )
+        with patch("httpx.Client") as mock_client_cls:
+            _mock_upstream(mock_client_cls, {"issuer": issuer})
+            TestClient(app).get("/.well-known/oauth-authorization-server")
+            assert mock_client_cls.call_args.kwargs["timeout"] == httpx.Timeout(2.5)
+
+    def test_get_has_cors_header(self, client, issuer):
+        with patch("httpx.Client") as mock_client_cls:
+            _mock_upstream(mock_client_cls, {"issuer": issuer})
+            response = client.get("/.well-known/oauth-authorization-server")
+            assert response.headers["access-control-allow-origin"] == "*"
+
+    def test_options_preflight(self, client):
+        response = client.options("/.well-known/oauth-authorization-server")
+        assert response.status_code == 204
+        assert response.headers["access-control-allow-origin"] == "*"
+        assert response.headers["access-control-allow-methods"] == "GET, OPTIONS"
+        assert (
+            response.headers["access-control-allow-headers"]
+            == "Content-Type, MCP-Protocol-Version"
+        )
+
+
+class TestJwksEndpoint:
+    def _client(self, issuer, jwks):
         app = Starlette(
             routes=[
                 well_known_metadata_mount(
@@ -132,9 +251,28 @@ class TestJwksEndpoint:
                 )
             ]
         )
-        response = TestClient(app).get("/.well-known/jwks.json")
+        return TestClient(app)
+
+    def test_returns_jwks_when_provided(self, issuer, sample_jwks):
+        response = self._client(issuer, sample_jwks).get("/.well-known/jwks.json")
         assert response.status_code == 200
         assert response.json()["keys"][0]["kid"] == "test-key-1"
+
+    def test_get_has_cors_header(self, issuer, sample_jwks):
+        response = self._client(issuer, sample_jwks).get("/.well-known/jwks.json")
+        assert response.headers["access-control-allow-origin"] == "*"
+
+    def test_options_preflight(self, issuer, sample_jwks):
+        response = self._client(issuer, sample_jwks).options(
+            "/.well-known/jwks.json"
+        )
+        assert response.status_code == 204
+        assert response.headers["access-control-allow-origin"] == "*"
+        assert response.headers["access-control-allow-methods"] == "GET, OPTIONS"
+        assert (
+            response.headers["access-control-allow-headers"]
+            == "Content-Type, MCP-Protocol-Version"
+        )
 
     def test_omitted_when_no_jwks(self, client):
         assert client.get("/.well-known/jwks.json").status_code == 404


### PR DESCRIPTION
Python half of ECO-77 (oauth-metadata-endpoints spec, keycard-sdk-spec #26). Companion TS PR: typescript-sdk (mcp 502 guard + express preflight/JWKS).

- **Protected-resource document** is now RFC 9728: drops the four non-standard client-registration fields (`client_id`, `client_name`, `token_endpoint_auth_method`, `grant_types`). Backend-verified dead weight: svc-iam reads only `authorization_servers` from PRM documents (`resolveProviderFromPRM`), and svc-sts resolves client JWKS from credential records, never from PRM.
- Gains the standard optional inputs `scopes_supported` / `resource_name` / `resource_documentation`; `jwks_uri` (standard RFC 9728 field) now emitted only when a JWKS is configured; `bearer_methods_supported` kept.
- **AS proxy** appends `resource=<origin>` to the upstream `authorization_endpoint` (matches express/cloudflare/Go), preserving existing query params.
- **CORS**: `Access-Control-Allow-Origin: *` on metadata + JWKS responses, plus OPTIONS preflight (204), matching the TS packages.
- **Timeout**: upstream metadata fetch configurable via `as_metadata_timeout` (default 10s; was fixed 5s).

BREAKING (closed alpha): document shape change as above.

Tests: starlette 97, mcp 542 (re-export assertions updated to the new contract), oauth 277 - all pass; ruff clean. Single release scope (`keycardai-starlette`; mcp changes are test-only), squash is fine.