### PR TITLE
fix(keycardai-starlette): return 502 when the upstream AS metadata fetch fails

### DIFF
--- a/packages/a2a/tests/test_agent_card_server.py
+++ b/packages/a2a/tests/test_agent_card_server.py
@@ -250,4 +250,4 @@ class TestOAuthMetadataEndpoints:
         response = client.get("/.well-known/oauth-authorization-server")
         # The endpoint proxies to the auth server which is unreachable in
         # tests; accept any non-error response shape.
-        assert response.status_code in (200, 302, 307, 503)
+        assert response.status_code in (200, 302, 307, 502)

--- a/packages/mcp/tests/keycardai/mcp/server/handlers/test_metadata.py
+++ b/packages/mcp/tests/keycardai/mcp/server/handlers/test_metadata.py
@@ -643,7 +643,7 @@ class TestAuthorizationServerMetadata:
         response = handler(request)
 
         # Verify error response
-        assert response.status_code == 404
+        assert response.status_code == 502
         response_data = json.loads(response.body)
         assert response_data["error"] == "Upstream authorization server returned 404: Not Found"
         assert response_data["type"] == "upstream_error"
@@ -665,10 +665,10 @@ class TestAuthorizationServerMetadata:
         response = handler(request)
 
         # Verify error response
-        assert response.status_code == 503
+        assert response.status_code == 502
         response_data = json.loads(response.body)
-        assert "Unable to connect to authorization server" in response_data["error"]
-        assert response_data["type"] == "connectivity_error"
+        assert "Unable to fetch authorization server metadata" in response_data["error"]
+        assert response_data["type"] == "upstream_error"
         assert response_data["url"] == "https://auth.example.com/.well-known/oauth-authorization-server"
 
     @patch("httpx.Client")
@@ -687,10 +687,10 @@ class TestAuthorizationServerMetadata:
         response = handler(request)
 
         # Verify error response
-        assert response.status_code == 503
+        assert response.status_code == 502
         response_data = json.loads(response.body)
-        assert "Unable to connect to authorization server" in response_data["error"]
-        assert response_data["type"] == "connectivity_error"
+        assert "Unable to fetch authorization server metadata" in response_data["error"]
+        assert response_data["type"] == "upstream_error"
 
     @patch("httpx.Client")
     def test_general_exception_handling(self, mock_client_class):

--- a/packages/starlette/src/keycardai/starlette/handlers/metadata.py
+++ b/packages/starlette/src/keycardai/starlette/handlers/metadata.py
@@ -228,16 +228,16 @@ def authorization_server_metadata(
                     "type": "upstream_error",
                     "url": str(e.request.url),
                 },
-                status_code=e.response.status_code,
+                status_code=502,
             )
-        except (httpx.ConnectError, httpx.TimeoutException) as e:
+        except httpx.HTTPError as e:
             return JSONResponse(
                 content={
-                    "error": f"Unable to connect to authorization server: {str(e)}",
-                    "type": "connectivity_error",
+                    "error": f"Unable to fetch authorization server metadata: {str(e)}",
+                    "type": "upstream_error",
                     "url": f"{actual_issuer}/.well-known/oauth-authorization-server",
                 },
-                status_code=503,
+                status_code=502,
             )
         except Exception as e:
             return JSONResponse(

--- a/packages/starlette/tests/keycardai/starlette/test_routers.py
+++ b/packages/starlette/tests/keycardai/starlette/test_routers.py
@@ -158,7 +158,7 @@ class TestAuthorizationServerMetadata:
             assert response.status_code == 200
             assert response.json()["issuer"] == issuer
 
-    def test_upstream_503_on_connect_error(self, client):
+    def test_upstream_502_on_connect_error(self, client):
         import httpx
 
         with patch("httpx.Client") as mock_client_cls:
@@ -166,7 +166,31 @@ class TestAuthorizationServerMetadata:
                 httpx.ConnectError("connection refused")
             )
             response = client.get("/.well-known/oauth-authorization-server")
-            assert response.status_code == 503
+            assert response.status_code == 502
+
+    def test_upstream_502_on_upstream_http_error(self, client):
+        import httpx
+
+        with patch("httpx.Client") as mock_client_cls:
+            mock_response = Mock()
+            mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+                "server error",
+                request=httpx.Request(
+                    "GET", "https://zone.example.com/.well-known/oauth-authorization-server"
+                ),
+                response=httpx.Response(
+                    500,
+                    request=httpx.Request(
+                        "GET",
+                        "https://zone.example.com/.well-known/oauth-authorization-server",
+                    ),
+                ),
+            )
+            mock_client_cls.return_value.__enter__.return_value.get.return_value = (
+                mock_response
+            )
+            response = client.get("/.well-known/oauth-authorization-server")
+            assert response.status_code == 502
 
     def test_authorization_endpoint_gains_resource_param(self, client, issuer):
         upstream = {


### PR DESCRIPTION
Closes the last Py/TS row in the oauth-metadata-endpoints spec (keycard-sdk-spec #26, follow-up to ECO-77/#168).

The AS metadata proxy previously passed the upstream HTTP status through and mapped connect/timeout to 503 (other exceptions 500). All TS packages and Go return 502 on upstream failure; Python now matches: any upstream HTTP error status or transport error responds `502` with an `upstream_error` JSON body. Unexpected internal exceptions still map to 500.

Tests: starlette 98, mcp 542 (handler re-export assertions updated) - all pass, ruff clean. Single release scope, squash is fine.