### PR TITLE
feat(keycardai-oauth): add issuer-direct entry to the PKCE authenticate flow

### DIFF
--- a/packages/oauth/src/keycardai/oauth/pkce/__init__.py
+++ b/packages/oauth/src/keycardai/oauth/pkce/__init__.py
@@ -3,10 +3,11 @@
 Builds on the lower-level PKCE primitives in :mod:`keycardai.oauth.utils.pkce`
 and reuses :class:`keycardai.oauth.AsyncClient` for the OAuth-server-facing
 operations (server metadata discovery, code exchange). This package owns the
-user-flow orchestration on top: discovery from a ``WWW-Authenticate``
-challenge (RFC 9728), local callback server (RFC 8252), and browser launch.
+user-flow orchestration on top: issuer resolution (directly via ``issuer``
+or from a ``WWW-Authenticate`` challenge per RFC 9728), local callback
+server (RFC 8252), and browser launch.
 
-Example::
+Example (challenge-driven)::
 
     from keycardai.oauth.pkce import authenticate
 
@@ -16,9 +17,16 @@ Example::
         www_authenticate_header=resp.headers["WWW-Authenticate"],
     )
     print(token.access_token)
+
+Example (issuer-direct)::
+
+    token = await authenticate(
+        client_id="my-app",
+        issuer="https://auth.example.com",
+    )
 """
 
 from .callback import OAuthCallbackServer
-from .client import authenticate
+from .client import authenticate, resolve_issuer_from_challenge
 
-__all__ = ["OAuthCallbackServer", "authenticate"]
+__all__ = ["OAuthCallbackServer", "authenticate", "resolve_issuer_from_challenge"]

--- a/packages/oauth/src/keycardai/oauth/pkce/client.py
+++ b/packages/oauth/src/keycardai/oauth/pkce/client.py
@@ -3,10 +3,10 @@
 The :func:`authenticate` function drives the full authorization code with
 PKCE flow:
 
-1. Parse the ``WWW-Authenticate`` challenge from the protected resource
-   (RFC 9728)
-2. Fetch protected resource metadata, then drive
-   :class:`keycardai.oauth.AsyncClient` against the discovered authorization
+1. Resolve the issuer: either directly from the ``issuer`` argument, or by
+   parsing the ``WWW-Authenticate`` challenge from the protected resource
+   (RFC 9728) and fetching its protected resource metadata
+2. Drive :class:`keycardai.oauth.AsyncClient` against the authorization
    server for metadata discovery (RFC 8414) and code exchange (RFC 6749 +
    RFC 7636)
 3. Generate a PKCE verifier/challenge pair (RFC 7636) and a CSRF state value
@@ -32,6 +32,7 @@ from typing import Any
 import httpx
 
 from ..client import AsyncClient
+from ..exceptions import ConfigError
 from ..http.auth import BasicAuth, NoneAuth
 from ..operations._authorize import build_authorize_url
 from ..types.models import ClientConfig, TokenResponse
@@ -44,8 +45,9 @@ logger = logging.getLogger(__name__)
 async def authenticate(
     *,
     client_id: str,
-    resource_url: str,
-    www_authenticate_header: str,
+    resource_url: str | None = None,
+    www_authenticate_header: str | None = None,
+    issuer: str | None = None,
     client_secret: str | None = None,
     redirect_uri: str = "http://localhost:8765/callback",
     callback_port: int = 8765,
@@ -53,8 +55,15 @@ async def authenticate(
     callback_timeout: int = 300,
     http_client: httpx.AsyncClient | None = None,
 ) -> TokenResponse:
-    """Run the OAuth 2.0 authorization-code-with-PKCE flow against the issuer
-    advertised by ``www_authenticate_header``.
+    """Run the OAuth 2.0 authorization-code-with-PKCE flow.
+
+    The authorization server is resolved through exactly one of two entries:
+
+    - Challenge-driven: pass ``www_authenticate_header`` (with
+      ``resource_url``); the issuer is resolved by parsing the RFC 9728
+      challenge and fetching the protected resource metadata.
+    - Issuer-direct: pass ``issuer``; challenge parsing and the metadata
+      fetch are skipped entirely.
 
     Targets desktop / CLI public clients running against a loopback redirect
     URI (RFC 8252). Confidential clients pass ``client_secret`` and get HTTP
@@ -64,10 +73,15 @@ async def authenticate(
         client_id: OAuth client ID.
         resource_url: The protected resource the caller is targeting. Passed
             through as the RFC 8707 ``resource`` parameter on both the
-            authorize and token requests.
+            authorize and token requests. Required in challenge mode;
+            optional in issuer mode (when omitted, no ``resource``
+            parameter is sent).
         www_authenticate_header: The ``WWW-Authenticate`` value from the
             resource's 401 response. Must contain a ``resource_metadata``
-            URL per RFC 9728.
+            URL per RFC 9728. Mutually exclusive with ``issuer``.
+        issuer: Authorization server issuer URL to use directly, skipping
+            challenge parsing and the protected resource metadata fetch.
+            Mutually exclusive with ``www_authenticate_header``.
         client_secret: Optional client secret for confidential clients.
             Public clients (the typical PKCE use case) omit this.
         redirect_uri: Loopback redirect URI registered with the authorization
@@ -86,6 +100,9 @@ async def authenticate(
         ``TokenResponse`` from the token endpoint.
 
     Raises:
+        keycardai.oauth.ConfigError: If both or neither of ``issuer`` and
+            ``www_authenticate_header`` are provided, or if challenge mode
+            is used without ``resource_url``.
         ValueError: If discovery fails (no ``resource_metadata`` in the
             challenge, no ``authorization_servers`` in the metadata, or the
             authorization server is missing required endpoints).
@@ -99,18 +116,25 @@ async def authenticate(
         RuntimeError: If the authorization redirect carried an OAuth
             ``error`` parameter.
     """
-    logger.info("PKCE flow starting for resource %s", resource_url)
+    if (issuer is None) == (www_authenticate_header is None):
+        raise ConfigError(
+            "Provide exactly one of 'issuer' or 'www_authenticate_header' "
+            "to authenticate()"
+        )
 
-    metadata_url = _extract_resource_metadata_url(www_authenticate_header)
-    if not metadata_url:
-        raise ValueError("No resource_metadata URL in WWW-Authenticate header")
-
-    resource_metadata = await _fetch_resource_metadata(metadata_url, http_client)
-    auth_servers = resource_metadata.get("authorization_servers") or []
-    if not auth_servers:
-        raise ValueError("No authorization_servers in resource metadata")
-
-    auth_server_url = auth_servers[0].rstrip("/")
+    if issuer is not None:
+        logger.info("PKCE flow starting against issuer %s", issuer)
+        auth_server_url = issuer.rstrip("/")
+    else:
+        if resource_url is None:
+            raise ConfigError(
+                "'resource_url' is required when authenticating from a "
+                "WWW-Authenticate challenge"
+            )
+        logger.info("PKCE flow starting for resource %s", resource_url)
+        auth_server_url = await resolve_issuer_from_challenge(
+            www_authenticate_header, http_client=http_client
+        )
 
     auth_strategy = (
         BasicAuth(client_id, client_secret) if client_secret else NoneAuth()
@@ -134,7 +158,7 @@ async def authenticate(
             client_id=client_id,
             redirect_uri=redirect_uri,
             pkce=pkce,
-            resources=[resource_url],
+            resources=[resource_url] if resource_url else None,
             scope=" ".join(scopes) if scopes else None,
             state=state,
         )
@@ -156,6 +180,45 @@ async def authenticate(
             client_id=client_id,
             resource=resource_url,
         )
+
+
+async def resolve_issuer_from_challenge(
+    www_authenticate_header: str,
+    *,
+    http_client: httpx.AsyncClient | None = None,
+) -> str:
+    """Resolve the authorization server issuer from a ``WWW-Authenticate`` challenge.
+
+    Parses the ``resource_metadata`` URL from the challenge (RFC 9728),
+    fetches the protected resource metadata document, and returns the first
+    entry of ``authorization_servers`` with any trailing slash removed.
+
+    Args:
+        www_authenticate_header: The ``WWW-Authenticate`` value from the
+            protected resource's 401 response.
+        http_client: Optional ``httpx.AsyncClient`` used to fetch the
+            protected resource metadata document. When not supplied, a
+            short-lived client is created internally.
+
+    Returns:
+        The issuer URL of the resource's first advertised authorization
+        server.
+
+    Raises:
+        ValueError: If the challenge has no ``resource_metadata`` URL or the
+            metadata document lists no ``authorization_servers``.
+        httpx.HTTPStatusError: If the resource metadata fetch fails.
+    """
+    metadata_url = _extract_resource_metadata_url(www_authenticate_header)
+    if not metadata_url:
+        raise ValueError("No resource_metadata URL in WWW-Authenticate header")
+
+    resource_metadata = await _fetch_resource_metadata(metadata_url, http_client)
+    auth_servers = resource_metadata.get("authorization_servers") or []
+    if not auth_servers:
+        raise ValueError("No authorization_servers in resource metadata")
+
+    return str(auth_servers[0]).rstrip("/")
 
 
 async def _fetch_resource_metadata(

--- a/packages/oauth/tests/keycardai/oauth/pkce/test_client.py
+++ b/packages/oauth/tests/keycardai/oauth/pkce/test_client.py
@@ -9,8 +9,13 @@ from unittest.mock import AsyncMock, MagicMock
 import httpx
 import pytest
 
+from keycardai.oauth.exceptions import ConfigError
 from keycardai.oauth.http.auth import BasicAuth, NoneAuth
-from keycardai.oauth.pkce import OAuthCallbackServer, authenticate
+from keycardai.oauth.pkce import (
+    OAuthCallbackServer,
+    authenticate,
+    resolve_issuer_from_challenge,
+)
 from keycardai.oauth.pkce.client import _extract_resource_metadata_url
 from keycardai.oauth.types.models import TokenResponse
 
@@ -158,6 +163,105 @@ async def test_authenticate_uses_none_auth_for_public_client(monkeypatch):
     )
 
     assert isinstance(captured["auth"], NoneAuth)
+
+
+@pytest.mark.asyncio
+async def test_authenticate_raises_when_neither_issuer_nor_header():
+    with pytest.raises(ConfigError, match="exactly one"):
+        await authenticate(client_id="cid")
+
+
+@pytest.mark.asyncio
+async def test_authenticate_raises_when_both_issuer_and_header():
+    with pytest.raises(ConfigError, match="exactly one"):
+        await authenticate(
+            client_id="cid",
+            issuer="https://auth.example.com",
+            www_authenticate_header=WWW_AUTHENTICATE,
+        )
+
+
+@pytest.mark.asyncio
+async def test_authenticate_raises_when_challenge_mode_missing_resource_url():
+    with pytest.raises(ConfigError, match="resource_url"):
+        await authenticate(
+            client_id="cid",
+            www_authenticate_header=WWW_AUTHENTICATE,
+        )
+
+
+@pytest.mark.asyncio
+async def test_authenticate_issuer_direct_skips_metadata_fetch(monkeypatch):
+    """Issuer mode drives the flow without any protected resource metadata request."""
+    _patch_callback_and_browser(monkeypatch, code="auth-code-456")
+    token_response = TokenResponse(
+        access_token="tok", token_type="Bearer", expires_in=3600
+    )
+    captured = {}
+    fake_async_client = _async_client_factory(
+        endpoints=MagicMock(
+            authorize="https://auth.example.com/authorize",
+            token="https://auth.example.com/token",
+        ),
+        exchange_response=token_response,
+        capture=captured,
+    )
+    monkeypatch.setattr(
+        "keycardai.oauth.pkce.client.AsyncClient", fake_async_client
+    )
+    http_mock = _http_client_mock([])
+
+    result = await authenticate(
+        client_id="my-app",
+        issuer="https://auth.example.com/",
+        resource_url="https://api.example.com",
+        http_client=http_mock,
+    )
+
+    assert result is token_response
+    # No protected resource metadata request was made.
+    http_mock.get.assert_not_awaited()
+    # AsyncClient was constructed against the issuer (trailing slash stripped).
+    assert captured["issuer"] == "https://auth.example.com"
+    # The RFC 8707 resource indicator was still passed to the token exchange.
+    assert captured["exchange_kwargs"]["resource"] == "https://api.example.com"
+
+
+@pytest.mark.asyncio
+async def test_authenticate_issuer_direct_without_resource_url(monkeypatch):
+    _patch_callback_and_browser(monkeypatch, code="code")
+    captured = {}
+    fake_async_client = _async_client_factory(
+        endpoints=MagicMock(
+            authorize="https://auth.example.com/authorize",
+            token="https://auth.example.com/token",
+        ),
+        exchange_response=TokenResponse(access_token="tok", token_type="Bearer"),
+        capture=captured,
+    )
+    monkeypatch.setattr(
+        "keycardai.oauth.pkce.client.AsyncClient", fake_async_client
+    )
+
+    await authenticate(client_id="public-app", issuer="https://auth.example.com")
+
+    assert captured["exchange_kwargs"]["resource"] is None
+
+
+@pytest.mark.asyncio
+async def test_resolve_issuer_from_challenge_resolves_issuer():
+    http_mock = _http_client_mock(
+        [{"authorization_servers": ["https://auth.example.com/"]}]
+    )
+
+    issuer = await resolve_issuer_from_challenge(
+        WWW_AUTHENTICATE, http_client=http_mock
+    )
+
+    assert issuer == "https://auth.example.com"
+    http_mock.get.assert_awaited_once_with(
+        "https://api.example.com/.well-known/oauth-protected-resource"
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Python half of ECO-86 (authorization-code-pkce spec, keycard-sdk-spec #21). Companion TS PR adds the challenge-driven half.

Decision: the canonical `authenticate` supports both entry modes. Python (previously challenge-only):

- `authenticate` accepts `issuer=` directly (no challenge parsing, no metadata fetch) OR the existing `www_authenticate_header=` challenge path; exactly one required (`ConfigError` otherwise).
- `resource_url` is now optional overall; still required in challenge mode (its prior contract), and in issuer mode omitting it sends no RFC 8707 `resource` parameter.
- The challenge-to-issuer resolution is now a public reusable helper: `keycardai.oauth.pkce.resolve_issuer_from_challenge`.

Backward compatible for all existing challenge-driven callers. 283 oauth tests pass (new: entry-mode validation, issuer-direct no-PRM-fetch assertion, resource passthrough/omission, helper resolution), ruff clean. Single scope, squash is fine.