### PR TITLE
feat(keycardai-oauth): add WorkloadIdentity credential with pluggable subject token sources

### DIFF
--- a/packages/oauth/src/keycardai/oauth/server/__init__.py
+++ b/packages/oauth/src/keycardai/oauth/server/__init__.py
@@ -13,7 +13,9 @@ Credential Providers:
     ApplicationCredential: Protocol for credential providers
     ClientSecret: Client credentials (BasicAuth) for token exchange
     WebIdentity: Private key JWT client assertion (RFC 7523)
-    EKSWorkloadIdentity: EKS workload identity with mounted tokens
+    WorkloadIdentity: Platform-signed OIDC token from a pluggable SubjectTokenSource
+    FileTokenSource, GCPMetadataTokenSource, FlyTokenSource: Built-in token sources
+    EKSWorkloadIdentity: Deprecated alias for WorkloadIdentity with a FileTokenSource
 
 Infrastructure:
     ClientFactory, DefaultClientFactory: OAuth client creation
@@ -26,7 +28,12 @@ from .credentials import (
     ApplicationCredential,
     ClientSecret,
     EKSWorkloadIdentity,
+    FileTokenSource,
+    FlyTokenSource,
+    GCPMetadataTokenSource,
+    SubjectTokenSource,
     WebIdentity,
+    WorkloadIdentity,
 )
 from .token_exchange import exchange_tokens_for_resources
 from .verifier import AccessToken, TokenVerifier
@@ -42,5 +49,10 @@ __all__ = [
     "ApplicationCredential",
     "ClientSecret",
     "EKSWorkloadIdentity",
+    "FileTokenSource",
+    "FlyTokenSource",
+    "GCPMetadataTokenSource",
+    "SubjectTokenSource",
     "WebIdentity",
+    "WorkloadIdentity",
 ]

--- a/packages/oauth/src/keycardai/oauth/server/__init__.py
+++ b/packages/oauth/src/keycardai/oauth/server/__init__.py
@@ -13,7 +13,7 @@ Credential Providers:
     ApplicationCredential: Protocol for credential providers
     ClientSecret: Client credentials (BasicAuth) for token exchange
     WebIdentity: Private key JWT client assertion (RFC 7523)
-    WorkloadIdentity: Platform-signed OIDC token from a pluggable SubjectTokenSource
+    WorkloadIdentity: Platform-signed OIDC token from a pluggable IdentityTokenSource
     FileTokenSource, GCPMetadataTokenSource, FlyTokenSource: Built-in token sources
     EKSWorkloadIdentity: Deprecated alias for WorkloadIdentity with a FileTokenSource
 
@@ -31,7 +31,7 @@ from .credentials import (
     FileTokenSource,
     FlyTokenSource,
     GCPMetadataTokenSource,
-    SubjectTokenSource,
+    IdentityTokenSource,
     WebIdentity,
     WorkloadIdentity,
 )
@@ -52,7 +52,7 @@ __all__ = [
     "FileTokenSource",
     "FlyTokenSource",
     "GCPMetadataTokenSource",
-    "SubjectTokenSource",
+    "IdentityTokenSource",
     "WebIdentity",
     "WorkloadIdentity",
 ]

--- a/packages/oauth/src/keycardai/oauth/server/credentials.py
+++ b/packages/oauth/src/keycardai/oauth/server/credentials.py
@@ -502,7 +502,8 @@ class WorkloadIdentity:
 
     Args:
         source: A IdentityTokenSource, or a bare callable (sync or async)
-            returning the token.
+            returning the token. A synchronous callable runs directly on the
+            event loop, so it must not perform blocking I/O.
         client_id: Optional ID of the Keycard application credential this
             workload authenticates as, sent as the client_id form parameter
             alongside the assertion. Token-federation application credentials

--- a/packages/oauth/src/keycardai/oauth/server/credentials.py
+++ b/packages/oauth/src/keycardai/oauth/server/credentials.py
@@ -8,7 +8,7 @@ authentication method.
 Credential Providers:
 - ClientSecret: Uses client credentials (BasicAuth) for token exchange
 - WebIdentity: Private key JWT client assertion (RFC 7523)
-- WorkloadIdentity: Platform-signed OIDC token from a pluggable SubjectTokenSource
+- WorkloadIdentity: Platform-signed OIDC token from a pluggable IdentityTokenSource
 - EKSWorkloadIdentity: Deprecated alias for WorkloadIdentity with a FileTokenSource
 """
 
@@ -284,7 +284,7 @@ WORKLOAD_IDENTITY_SOURCE_FLY = "fly"
 WORKLOAD_IDENTITY_SOURCE_CUSTOM = "custom"
 
 
-class SubjectTokenSource(Protocol):
+class IdentityTokenSource(Protocol):
     """Supplies a platform-signed OIDC token for use as a client assertion.
 
     The only per-platform piece of a workload identity credential:
@@ -294,12 +294,12 @@ class SubjectTokenSource(Protocol):
     Cloud Run), FlyTokenSource covers Fly Machines, and any bare callable
     returning the token (sync or async) is accepted as a source.
 
-    subject_token is called on every token exchange. Implementations must
+    identity_token is called on every token exchange. Implementations must
     return the current token; platforms rotate these tokens, so returning a
     stale cached value risks an expired assertion.
     """
 
-    async def subject_token(self) -> str:
+    async def identity_token(self) -> str:
         """Return the current platform-signed OIDC token."""
         ...
 
@@ -367,7 +367,7 @@ class FileTokenSource:
             )
         return token
 
-    async def subject_token(self) -> str:
+    async def identity_token(self) -> str:
         """Re-read the token file and return its stripped contents."""
         return self._read(WorkloadIdentityRuntimeError)
 
@@ -398,7 +398,7 @@ class GCPMetadataTokenSource:
         self.timeout = timeout
         self._transport = _transport
 
-    async def subject_token(self) -> str:
+    async def identity_token(self) -> str:
         """Request a GCP-signed OIDC JWT from the metadata server."""
         try:
             async with httpx.AsyncClient(
@@ -451,7 +451,7 @@ class FlyTokenSource:
         self.socket_path = socket_path
         self._transport = _transport
 
-    async def subject_token(self) -> str:
+    async def identity_token(self) -> str:
         """Request a Fly-signed OIDC JWT from the Machines API."""
         transport = self._transport or httpx.AsyncHTTPTransport(uds=self.socket_path)
         payload = {"aud": self.audience} if self.audience else {}
@@ -501,7 +501,7 @@ class WorkloadIdentity:
         provider = WorkloadIdentity(my_async_fetch)
 
     Args:
-        source: A SubjectTokenSource, or a bare callable (sync or async)
+        source: A IdentityTokenSource, or a bare callable (sync or async)
             returning the token.
         client_id: Optional ID of the Keycard application credential this
             workload authenticates as, sent as the client_id form parameter
@@ -513,24 +513,24 @@ class WorkloadIdentity:
 
     def __init__(
         self,
-        source: "SubjectTokenSource | Callable[[], Awaitable[str] | str]",
+        source: "IdentityTokenSource | Callable[[], Awaitable[str] | str]",
         client_id: str | None = None,
     ):
         if source is None:
             raise WorkloadIdentityConfigurationError(
-                "subject token source must not be None"
+                "identity token source must not be None"
             )
-        if not callable(getattr(source, "subject_token", None)) and not callable(
+        if not callable(getattr(source, "identity_token", None)) and not callable(
             source
         ):
             raise WorkloadIdentityConfigurationError(
-                "subject token source must provide subject_token() or be callable"
+                "identity token source must provide identity_token() or be callable"
             )
         self._source = source
         self.client_id = client_id
 
-    async def _fetch_subject_token(self) -> str:
-        fetch = getattr(self._source, "subject_token", None)
+    async def _fetch_identity_token(self) -> str:
+        fetch = getattr(self._source, "identity_token", None)
         if not callable(fetch):
             fetch = self._source
         try:
@@ -540,12 +540,12 @@ class WorkloadIdentity:
             raise
         except Exception as err:
             raise WorkloadIdentityRuntimeError(
-                "Error fetching subject token",
+                "Error fetching identity token",
                 source=WORKLOAD_IDENTITY_SOURCE_CUSTOM,
             ) from err
         if not isinstance(token, str) or not token.strip():
             raise WorkloadIdentityRuntimeError(
-                "Subject token source returned an empty token",
+                "Identity token source returned an empty token",
                 source=WORKLOAD_IDENTITY_SOURCE_CUSTOM,
             )
         return token
@@ -567,7 +567,7 @@ class WorkloadIdentity:
         resource: str,
         auth_info: dict[str, str] | None = None,
     ) -> TokenExchangeRequest:
-        assertion = await self._fetch_subject_token()
+        assertion = await self._fetch_identity_token()
 
         return TokenExchangeRequest(
             subject_token=subject_token,

--- a/packages/oauth/src/keycardai/oauth/server/credentials.py
+++ b/packages/oauth/src/keycardai/oauth/server/credentials.py
@@ -8,13 +8,18 @@ authentication method.
 Credential Providers:
 - ClientSecret: Uses client credentials (BasicAuth) for token exchange
 - WebIdentity: Private key JWT client assertion (RFC 7523)
-- EKSWorkloadIdentity: EKS workload identity with mounted tokens
+- WorkloadIdentity: Platform-signed OIDC token from a pluggable SubjectTokenSource
+- EKSWorkloadIdentity: Deprecated alias for WorkloadIdentity with a FileTokenSource
 """
 
+import inspect
 import os
 import uuid
 import warnings
+from collections.abc import Awaitable, Callable
 from typing import Protocol
+
+import httpx
 
 from keycardai.oauth import (
     AsyncClient,
@@ -31,6 +36,8 @@ from .exceptions import (
     ClientSecretConfigurationError,
     EKSWorkloadIdentityConfigurationError,
     EKSWorkloadIdentityRuntimeError,
+    WorkloadIdentityConfigurationError,
+    WorkloadIdentityRuntimeError,
 )
 from .private_key import (
     FilePrivateKeyStorage,
@@ -269,8 +276,314 @@ class WebIdentity:
         )
 
 
-class EKSWorkloadIdentity:
+# Source identifiers carried on WorkloadIdentityConfigurationError and
+# WorkloadIdentityRuntimeError, for branching on which token source failed.
+WORKLOAD_IDENTITY_SOURCE_FILE = "file"
+WORKLOAD_IDENTITY_SOURCE_GCP_METADATA = "gcp-metadata"
+WORKLOAD_IDENTITY_SOURCE_FLY = "fly"
+WORKLOAD_IDENTITY_SOURCE_CUSTOM = "custom"
+
+
+class SubjectTokenSource(Protocol):
+    """Supplies a platform-signed OIDC token for use as a client assertion.
+
+    The only per-platform piece of a workload identity credential:
+    FileTokenSource covers platforms that project the token to a file (EKS,
+    AKS, Kubernetes projected service-account tokens), GCPMetadataTokenSource
+    covers platforms that serve it from the GCP metadata endpoint (GKE, GCE,
+    Cloud Run), FlyTokenSource covers Fly Machines, and any bare callable
+    returning the token (sync or async) is accepted as a source.
+
+    subject_token is called on every token exchange. Implementations must
+    return the current token; platforms rotate these tokens, so returning a
+    stale cached value risks an expired assertion.
+    """
+
+    async def subject_token(self) -> str:
+        """Return the current platform-signed OIDC token."""
+        ...
+
+
+class FileTokenSource:
+    """Reads a platform-projected OIDC token from a mounted file.
+
+    The file is re-read on every call (platforms rotate projected tokens).
+    Covers EKS pod identity, AKS workload identity, any Kubernetes projected
+    service-account token, and CI providers that write the token to a file.
+
+    Environment variable discovery (when token_file_path is not provided):
+        1. The variable named by env_var_name, when given
+        2. KEYCARD_EKS_WORKLOAD_IDENTITY_TOKEN_FILE
+        3. AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE
+        4. AWS_WEB_IDENTITY_TOKEN_FILE
+        5. AZURE_FEDERATED_TOKEN_FILE
+    """
+
+    default_env_var_names = [
+        "KEYCARD_EKS_WORKLOAD_IDENTITY_TOKEN_FILE",
+        "AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE",
+        "AWS_WEB_IDENTITY_TOKEN_FILE",
+        "AZURE_FEDERATED_TOKEN_FILE",
+    ]
+
+    def __init__(
+        self,
+        token_file_path: str | None = None,
+        env_var_name: str | None = None,
+    ):
+        if token_file_path is None:
+            env_names = (
+                self.default_env_var_names
+                if env_var_name is None
+                else [env_var_name, *self.default_env_var_names]
+            )
+            token_file_path = next(
+                (os.environ.get(name) for name in env_names if os.environ.get(name)),
+                None,
+            )
+            if not token_file_path:
+                raise WorkloadIdentityConfigurationError(
+                    "Could not find token file path in environment variables; "
+                    f"checked: {', '.join(env_names)}",
+                    source=WORKLOAD_IDENTITY_SOURCE_FILE,
+                )
+
+        self.token_file_path = token_file_path
+        self._read(WorkloadIdentityConfigurationError)
+
+    def _read(self, error_cls: type) -> str:
+        try:
+            with open(self.token_file_path) as f:
+                token = f.read().strip()
+        except OSError as err:
+            raise error_cls(
+                f"Error reading token file: {self.token_file_path}",
+                source=WORKLOAD_IDENTITY_SOURCE_FILE,
+            ) from err
+        if not token:
+            raise error_cls(
+                f"Token file is empty: {self.token_file_path}",
+                source=WORKLOAD_IDENTITY_SOURCE_FILE,
+            )
+        return token
+
+    async def subject_token(self) -> str:
+        """Re-read the token file and return its stripped contents."""
+        return self._read(WorkloadIdentityRuntimeError)
+
+
+class GCPMetadataTokenSource:
+    """Fetches an OIDC identity token from the GCP metadata server.
+
+    Requests a token for the default service account with the given audience,
+    typically the Keycard zone URL. Covers GKE, GCE, and Cloud Run.
+    """
+
+    _IDENTITY_PATH = "/computeMetadata/v1/instance/service-accounts/default/identity"
+
+    def __init__(
+        self,
+        audience: str,
+        metadata_url: str = "http://metadata.google.internal",
+        timeout: float = 5.0,
+        _transport: httpx.AsyncBaseTransport | None = None,
+    ):
+        if not audience or not audience.strip():
+            raise WorkloadIdentityConfigurationError(
+                "audience must not be empty",
+                source=WORKLOAD_IDENTITY_SOURCE_GCP_METADATA,
+            )
+        self.audience = audience
+        self.metadata_url = metadata_url.rstrip("/")
+        self.timeout = timeout
+        self._transport = _transport
+
+    async def subject_token(self) -> str:
+        """Request a GCP-signed OIDC JWT from the metadata server."""
+        try:
+            async with httpx.AsyncClient(
+                timeout=self.timeout, transport=self._transport
+            ) as client:
+                response = await client.get(
+                    self.metadata_url + self._IDENTITY_PATH,
+                    params={"audience": self.audience, "format": "full"},
+                    headers={"Metadata-Flavor": "Google"},
+                )
+        except httpx.HTTPError as err:
+            raise WorkloadIdentityRuntimeError(
+                f"Error calling metadata server at {self.metadata_url} "
+                "(is this running on GCP?)",
+                source=WORKLOAD_IDENTITY_SOURCE_GCP_METADATA,
+            ) from err
+
+        if response.status_code != 200:
+            raise WorkloadIdentityRuntimeError(
+                f"Metadata server returned status {response.status_code}",
+                source=WORKLOAD_IDENTITY_SOURCE_GCP_METADATA,
+            )
+        token = response.text.strip()
+        if not token:
+            raise WorkloadIdentityRuntimeError(
+                "Metadata server returned an empty token",
+                source=WORKLOAD_IDENTITY_SOURCE_GCP_METADATA,
+            )
+        return token
+
+
+class FlyTokenSource:
+    """Fetches an OIDC token from the Fly.io Machines API over the local Unix socket.
+
+    Covers workloads running on Fly Machines. The socket is not probed at
+    construction; an unreachable Machines API surfaces as a
+    WorkloadIdentityRuntimeError at the first fetch.
+    """
+
+    _TOKEN_URL = "http://localhost/v1/tokens/oidc"
+    _TIMEOUT = 5.0
+
+    def __init__(
+        self,
+        audience: str | None = None,
+        socket_path: str = "/.fly/api",
+        _transport: httpx.AsyncBaseTransport | None = None,
+    ):
+        self.audience = audience
+        self.socket_path = socket_path
+        self._transport = _transport
+
+    async def subject_token(self) -> str:
+        """Request a Fly-signed OIDC JWT from the Machines API."""
+        transport = self._transport or httpx.AsyncHTTPTransport(uds=self.socket_path)
+        payload = {"aud": self.audience} if self.audience else {}
+        try:
+            async with httpx.AsyncClient(
+                transport=transport, timeout=self._TIMEOUT
+            ) as client:
+                response = await client.post(self._TOKEN_URL, json=payload)
+        except httpx.HTTPError as err:
+            raise WorkloadIdentityRuntimeError(
+                f"Error calling Machines API socket {self.socket_path} "
+                "(is this running on a Fly Machine?)",
+                source=WORKLOAD_IDENTITY_SOURCE_FLY,
+            ) from err
+
+        if response.status_code != 200:
+            raise WorkloadIdentityRuntimeError(
+                f"Machines API returned status {response.status_code}",
+                source=WORKLOAD_IDENTITY_SOURCE_FLY,
+            )
+        token = response.text.strip()
+        if not token:
+            raise WorkloadIdentityRuntimeError(
+                "Machines API returned an empty token",
+                source=WORKLOAD_IDENTITY_SOURCE_FLY,
+            )
+        return token
+
+
+class WorkloadIdentity:
+    """Workload identity provider using a platform-signed OIDC token.
+
+    On every token exchange it fetches the current token from the source and
+    attaches it as a jwt-bearer client assertion. It holds no shared secret
+    and never caches the token across requests.
+
+    Example:
+        # EKS / AKS / Kubernetes projected token (path discovered from env)
+        provider = WorkloadIdentity(FileTokenSource())
+
+        # GKE / GCE / Cloud Run
+        provider = WorkloadIdentity(
+            GCPMetadataTokenSource(audience="https://zone.keycard.cloud")
+        )
+
+        # Custom fetch
+        provider = WorkloadIdentity(my_async_fetch)
+
+    Args:
+        source: A SubjectTokenSource, or a bare callable (sync or async)
+            returning the token.
+        client_id: Optional ID of the Keycard application credential this
+            workload authenticates as, sent as the client_id form parameter
+            alongside the assertion. Token-federation application credentials
+            are resolved by this ID, so they require it; legacy token
+            credentials are resolved by the assertion's subject and do not
+            use it.
+    """
+
+    def __init__(
+        self,
+        source: "SubjectTokenSource | Callable[[], Awaitable[str] | str]",
+        client_id: str | None = None,
+    ):
+        if source is None:
+            raise WorkloadIdentityConfigurationError(
+                "subject token source must not be None"
+            )
+        if not callable(getattr(source, "subject_token", None)) and not callable(
+            source
+        ):
+            raise WorkloadIdentityConfigurationError(
+                "subject token source must provide subject_token() or be callable"
+            )
+        self._source = source
+        self.client_id = client_id
+
+    async def _fetch_subject_token(self) -> str:
+        fetch = getattr(self._source, "subject_token", None)
+        if not callable(fetch):
+            fetch = self._source
+        try:
+            result = fetch()
+            token = await result if inspect.isawaitable(result) else result
+        except (WorkloadIdentityConfigurationError, WorkloadIdentityRuntimeError):
+            raise
+        except Exception as err:
+            raise WorkloadIdentityRuntimeError(
+                "Error fetching subject token",
+                source=WORKLOAD_IDENTITY_SOURCE_CUSTOM,
+            ) from err
+        if not isinstance(token, str) or not token.strip():
+            raise WorkloadIdentityRuntimeError(
+                "Subject token source returned an empty token",
+                source=WORKLOAD_IDENTITY_SOURCE_CUSTOM,
+            )
+        return token
+
+    def get_http_client_auth(self) -> AuthStrategy:
+        return NoneAuth()
+
+    def set_client_config(
+        self,
+        config: ClientConfig,
+        auth_info: dict[str, str],
+    ) -> ClientConfig:
+        return config
+
+    async def prepare_token_exchange_request(
+        self,
+        client: AsyncClient,
+        subject_token: str,
+        resource: str,
+        auth_info: dict[str, str] | None = None,
+    ) -> TokenExchangeRequest:
+        assertion = await self._fetch_subject_token()
+
+        return TokenExchangeRequest(
+            subject_token=subject_token,
+            resource=resource,
+            subject_token_type="urn:ietf:params:oauth:token-type:access_token",
+            client_assertion_type=GrantType.JWT_BEARER_CLIENT_ASSERTION,
+            client_assertion=assertion,
+            client_id=self.client_id,
+        )
+
+
+class EKSWorkloadIdentity(WorkloadIdentity):
     """EKS workload identity provider using mounted tokens.
+
+    Deprecated: use WorkloadIdentity with FileTokenSource, which also covers
+    AKS and other platforms that project token files.
 
     This provider implements token exchange using EKS Pod Identity tokens that are
     mounted into the pod's filesystem. The token file location is configured either
@@ -317,6 +630,10 @@ class EKSWorkloadIdentity:
                 )
 
         self._validate_token_file()
+        super().__init__(source=self._read_token_async)
+
+    async def _read_token_async(self) -> str:
+        return self._read_token()
 
     def _get_token_file_path(
         self, env_var_name: str | None
@@ -398,29 +715,3 @@ class EKSWorkloadIdentity:
                 error_details=f"Error reading token file: {str(e)}",
             ) from e
 
-    def get_http_client_auth(self) -> AuthStrategy:
-        return NoneAuth()
-
-    def set_client_config(
-        self,
-        config: ClientConfig,
-        auth_info: dict[str, str],
-    ) -> ClientConfig:
-        return config
-
-    async def prepare_token_exchange_request(
-        self,
-        client: AsyncClient,
-        subject_token: str,
-        resource: str,
-        auth_info: dict[str, str] | None = None,
-    ) -> TokenExchangeRequest:
-        eks_token = self._read_token()
-
-        return TokenExchangeRequest(
-            subject_token=subject_token,
-            resource=resource,
-            subject_token_type="urn:ietf:params:oauth:token-type:access_token",
-            client_assertion_type=GrantType.JWT_BEARER_CLIENT_ASSERTION,
-            client_assertion=eks_token,
-        )

--- a/packages/oauth/src/keycardai/oauth/server/exceptions.py
+++ b/packages/oauth/src/keycardai/oauth/server/exceptions.py
@@ -469,8 +469,58 @@ class ClientInitializationError(OAuthServerError):
         super().__init__(message)
 
 
-class EKSWorkloadIdentityConfigurationError(OAuthServerError):
-    """Raised when EKS Workload Identity is misconfigured at initialization."""
+class WorkloadIdentityConfigurationError(OAuthServerError):
+    """Raised when a workload identity credential or token source is misconfigured.
+
+    Raised at construction: a missing or empty token file, no discovery
+    environment variable set, a missing required audience, or an invalid
+    source.
+
+    Attributes:
+        source: Identifies the token source ("file", "gcp-metadata", "fly");
+            None when the fault is in the credential itself.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        source: str | None = None,
+        details: dict | None = None,
+    ):
+        self.source = source
+        super().__init__(message, details=details)
+
+
+class WorkloadIdentityRuntimeError(OAuthServerError):
+    """Raised when the subject token cannot be obtained at request time.
+
+    Distinct from WorkloadIdentityConfigurationError, which is a
+    construction-time fault. Examples: the token file was rotated away or
+    emptied after construction, or the platform endpoint was unreachable.
+
+    Attributes:
+        source: Identifies the token source ("file", "gcp-metadata", "fly",
+            or "custom" for a source whose error is not one of this module's
+            typed errors).
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        source: str | None = None,
+        details: dict | None = None,
+    ):
+        self.source = source
+        super().__init__(message, details=details)
+
+
+class EKSWorkloadIdentityConfigurationError(WorkloadIdentityConfigurationError):
+    """Raised when EKS Workload Identity is misconfigured at initialization.
+
+    Deprecated: catch WorkloadIdentityConfigurationError instead.
+    """
 
     def __init__(
         self,
@@ -517,11 +567,14 @@ class EKSWorkloadIdentityConfigurationError(OAuthServerError):
             "solution": "Verify EKS workload identity configuration and token file accessibility",
         }
 
-        super().__init__(message, details=details)
+        super().__init__(message, source="file", details=details)
 
 
-class EKSWorkloadIdentityRuntimeError(OAuthServerError):
-    """Raised when EKS Workload Identity token cannot be read at runtime."""
+class EKSWorkloadIdentityRuntimeError(WorkloadIdentityRuntimeError):
+    """Raised when EKS Workload Identity token cannot be read at runtime.
+
+    Deprecated: catch WorkloadIdentityRuntimeError instead.
+    """
 
     def __init__(
         self,
@@ -563,7 +616,7 @@ class EKSWorkloadIdentityRuntimeError(OAuthServerError):
             "solution": "Verify token file is accessible and not corrupted. Check token rotation if applicable.",
         }
 
-        super().__init__(message, details=details)
+        super().__init__(message, source="file", details=details)
 
 
 class ClientSecretConfigurationError(OAuthServerError):

--- a/packages/oauth/tests/keycardai/oauth/server/test_workload_identity.py
+++ b/packages/oauth/tests/keycardai/oauth/server/test_workload_identity.py
@@ -166,7 +166,7 @@ class TestFileTokenSource:
 
         source = FileTokenSource(token_file_path=str(token_file))
 
-        assert await source.subject_token() == "projected-token"
+        assert await source.identity_token() == "projected-token"
 
     def test_configuration_error_on_missing_file(self, tmp_path):
         with pytest.raises(WorkloadIdentityConfigurationError) as exc_info:
@@ -184,7 +184,7 @@ class TestFileTokenSource:
             monkeypatch.setenv(env_name, str(token_file))
 
             source = FileTokenSource()
-            assert await source.subject_token() == "discovered-token", (
+            assert await source.identity_token() == "discovered-token", (
                 f"{env_name} must be discovered"
             )
 
@@ -202,7 +202,7 @@ class TestFileTokenSource:
         )
 
         source = FileTokenSource(env_var_name="CUSTOM_TOKEN_FILE")
-        assert await source.subject_token() == "custom-token"
+        assert await source.identity_token() == "custom-token"
 
     def test_configuration_error_without_path_or_env(self, monkeypatch):
         self._clear_discovery_env(monkeypatch)
@@ -218,7 +218,7 @@ class TestFileTokenSource:
 
         token_file.write_text("rotated-token")
 
-        assert await source.subject_token() == "rotated-token"
+        assert await source.identity_token() == "rotated-token"
 
     @pytest.mark.asyncio
     async def test_runtime_error_after_construction(self, tmp_path):
@@ -229,7 +229,7 @@ class TestFileTokenSource:
         os.remove(token_file)
 
         with pytest.raises(WorkloadIdentityRuntimeError) as exc_info:
-            await source.subject_token()
+            await source.identity_token()
         assert exc_info.value.source == "file"
 
 
@@ -281,7 +281,7 @@ class TestGCPMetadataTokenSource:
             _transport=httpx.MockTransport(handler),
         )
 
-        token = await source.subject_token()
+        token = await source.identity_token()
 
         assert token == "gcp-identity-token"
         assert seen["path"] == (
@@ -307,7 +307,7 @@ class TestGCPMetadataTokenSource:
         )
 
         with pytest.raises(WorkloadIdentityRuntimeError) as exc_info:
-            await source.subject_token()
+            await source.identity_token()
         assert exc_info.value.source == "gcp-metadata"
 
     @pytest.mark.asyncio
@@ -321,7 +321,7 @@ class TestGCPMetadataTokenSource:
         )
 
         with pytest.raises(WorkloadIdentityRuntimeError) as exc_info:
-            await source.subject_token()
+            await source.identity_token()
         assert exc_info.value.__cause__ is not None
 
 
@@ -342,7 +342,7 @@ class TestFlyTokenSource:
             _transport=httpx.MockTransport(handler),
         )
 
-        token = await source.subject_token()
+        token = await source.identity_token()
 
         assert token == "fly-oidc-token"
         assert seen["method"] == "POST"
@@ -360,7 +360,7 @@ class TestFlyTokenSource:
 
         source = FlyTokenSource(_transport=httpx.MockTransport(handler))
 
-        await source.subject_token()
+        await source.identity_token()
 
         assert seen["body"] == "{}"
 
@@ -373,7 +373,7 @@ class TestFlyTokenSource:
         )
 
         with pytest.raises(WorkloadIdentityRuntimeError) as exc_info:
-            await source.subject_token()
+            await source.identity_token()
         assert exc_info.value.source == "fly"
 
     @pytest.mark.asyncio
@@ -381,7 +381,7 @@ class TestFlyTokenSource:
         source = FlyTokenSource(socket_path=str(tmp_path / "no-such.sock"))
 
         with pytest.raises(WorkloadIdentityRuntimeError) as exc_info:
-            await source.subject_token()
+            await source.identity_token()
         assert exc_info.value.__cause__ is not None
 
     @pytest.mark.asyncio
@@ -409,7 +409,7 @@ class TestFlyTokenSource:
         server = await asyncio.start_unix_server(serve, path=socket_path)
         try:
             source = FlyTokenSource(socket_path=socket_path)
-            assert await source.subject_token() == "fly-oidc-token"
+            assert await source.identity_token() == "fly-oidc-token"
         finally:
             server.close()
             await server.wait_closed()

--- a/packages/oauth/tests/keycardai/oauth/server/test_workload_identity.py
+++ b/packages/oauth/tests/keycardai/oauth/server/test_workload_identity.py
@@ -1,0 +1,416 @@
+"""Unit tests for the WorkloadIdentity credential and its token sources.
+
+Follows the conformance table in the workload-identity spec
+(keycard-sdk-spec, specs/application-credentials/workload-identity.md).
+"""
+
+import asyncio
+import os
+import shutil
+import tempfile
+
+import httpx
+import pytest
+
+from keycardai.oauth import NoneAuth
+from keycardai.oauth.server.credentials import (
+    EKSWorkloadIdentity,
+    FileTokenSource,
+    FlyTokenSource,
+    GCPMetadataTokenSource,
+    WorkloadIdentity,
+)
+from keycardai.oauth.server.exceptions import (
+    WorkloadIdentityConfigurationError,
+    WorkloadIdentityRuntimeError,
+)
+
+
+async def async_token_source() -> str:
+    return "platform-token"
+
+
+class TestWorkloadIdentity:
+    def test_rejects_none_source(self):
+        with pytest.raises(WorkloadIdentityConfigurationError):
+            WorkloadIdentity(None)
+
+    def test_rejects_non_callable_source(self):
+        with pytest.raises(WorkloadIdentityConfigurationError):
+            WorkloadIdentity(object())
+
+    def test_no_basic_auth(self):
+        provider = WorkloadIdentity(async_token_source)
+        assert isinstance(provider.get_http_client_auth(), NoneAuth)
+
+    @pytest.mark.asyncio
+    async def test_prepares_request_from_source(self):
+        provider = WorkloadIdentity(async_token_source)
+
+        request = await provider.prepare_token_exchange_request(
+            client=None,
+            subject_token="subject-token",
+            resource="https://resource.example.com",
+        )
+
+        assert request.client_assertion == "platform-token"
+        assert (
+            request.client_assertion_type
+            == "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
+        )
+        assert request.subject_token == "subject-token"
+        assert request.subject_token_type == "urn:ietf:params:oauth:token-type:access_token"
+        assert request.resource == "https://resource.example.com"
+        assert request.client_id is None
+
+    @pytest.mark.asyncio
+    async def test_client_id_carried_when_configured(self):
+        provider = WorkloadIdentity(async_token_source, client_id="acr_123")
+
+        request = await provider.prepare_token_exchange_request(
+            client=None,
+            subject_token="subject-token",
+            resource="https://resource.example.com",
+        )
+
+        assert request.client_id == "acr_123"
+
+    @pytest.mark.asyncio
+    async def test_sync_callable_accepted(self):
+        provider = WorkloadIdentity(lambda: "sync-token")
+
+        request = await provider.prepare_token_exchange_request(
+            client=None,
+            subject_token="subject-token",
+            resource="https://resource.example.com",
+        )
+
+        assert request.client_assertion == "sync-token"
+
+    @pytest.mark.asyncio
+    async def test_fetches_fresh_token_every_exchange(self):
+        calls = 0
+
+        async def counting_source() -> str:
+            nonlocal calls
+            calls += 1
+            return f"token-{calls}"
+
+        provider = WorkloadIdentity(counting_source)
+        for expected in (1, 2):
+            request = await provider.prepare_token_exchange_request(
+                client=None,
+                subject_token="subject-token",
+                resource="https://resource.example.com",
+            )
+            assert request.client_assertion == f"token-{expected}", (
+                "the credential must not cache the token across exchanges"
+            )
+        assert calls == 2
+
+    @pytest.mark.asyncio
+    async def test_wraps_custom_source_error(self):
+        cause = RuntimeError("socket unavailable")
+
+        async def failing_source() -> str:
+            raise cause
+
+        provider = WorkloadIdentity(failing_source)
+        with pytest.raises(WorkloadIdentityRuntimeError) as exc_info:
+            await provider.prepare_token_exchange_request(
+                client=None,
+                subject_token="subject-token",
+                resource="https://resource.example.com",
+            )
+        assert exc_info.value.source == "custom"
+        assert exc_info.value.__cause__ is cause
+
+    @pytest.mark.asyncio
+    async def test_passes_through_typed_source_error(self):
+        typed = WorkloadIdentityRuntimeError("token file is empty", source="file")
+
+        async def failing_source() -> str:
+            raise typed
+
+        provider = WorkloadIdentity(failing_source)
+        with pytest.raises(WorkloadIdentityRuntimeError) as exc_info:
+            await provider.prepare_token_exchange_request(
+                client=None,
+                subject_token="subject-token",
+                resource="https://resource.example.com",
+            )
+        assert exc_info.value is typed, "the source's own typed error must pass through"
+        assert exc_info.value.source == "file"
+
+    @pytest.mark.asyncio
+    async def test_rejects_empty_token_from_source(self):
+        provider = WorkloadIdentity(lambda: "   \n")
+
+        with pytest.raises(WorkloadIdentityRuntimeError):
+            await provider.prepare_token_exchange_request(
+                client=None,
+                subject_token="subject-token",
+                resource="https://resource.example.com",
+            )
+
+
+class TestFileTokenSource:
+    def _clear_discovery_env(self, monkeypatch):
+        for name in FileTokenSource.default_env_var_names:
+            monkeypatch.delenv(name, raising=False)
+
+    @pytest.mark.asyncio
+    async def test_explicit_path(self, tmp_path):
+        token_file = tmp_path / "token"
+        token_file.write_text("projected-token\n")
+
+        source = FileTokenSource(token_file_path=str(token_file))
+
+        assert await source.subject_token() == "projected-token"
+
+    def test_configuration_error_on_missing_file(self, tmp_path):
+        with pytest.raises(WorkloadIdentityConfigurationError) as exc_info:
+            FileTokenSource(token_file_path=str(tmp_path / "does-not-exist"))
+        assert exc_info.value.source == "file"
+        assert isinstance(exc_info.value.__cause__, FileNotFoundError)
+
+    @pytest.mark.asyncio
+    async def test_env_discovery_each_variable(self, tmp_path, monkeypatch):
+        token_file = tmp_path / "token"
+        token_file.write_text("discovered-token")
+
+        for env_name in FileTokenSource.default_env_var_names:
+            self._clear_discovery_env(monkeypatch)
+            monkeypatch.setenv(env_name, str(token_file))
+
+            source = FileTokenSource()
+            assert await source.subject_token() == "discovered-token", (
+                f"{env_name} must be discovered"
+            )
+
+    @pytest.mark.asyncio
+    async def test_custom_env_var_wins(self, tmp_path, monkeypatch):
+        custom_file = tmp_path / "custom"
+        custom_file.write_text("custom-token")
+        default_file = tmp_path / "default"
+        default_file.write_text("default-token")
+
+        self._clear_discovery_env(monkeypatch)
+        monkeypatch.setenv("CUSTOM_TOKEN_FILE", str(custom_file))
+        monkeypatch.setenv(
+            "KEYCARD_EKS_WORKLOAD_IDENTITY_TOKEN_FILE", str(default_file)
+        )
+
+        source = FileTokenSource(env_var_name="CUSTOM_TOKEN_FILE")
+        assert await source.subject_token() == "custom-token"
+
+    def test_configuration_error_without_path_or_env(self, monkeypatch):
+        self._clear_discovery_env(monkeypatch)
+
+        with pytest.raises(WorkloadIdentityConfigurationError):
+            FileTokenSource()
+
+    @pytest.mark.asyncio
+    async def test_fresh_read_after_rotation(self, tmp_path):
+        token_file = tmp_path / "token"
+        token_file.write_text("initial-token")
+        source = FileTokenSource(token_file_path=str(token_file))
+
+        token_file.write_text("rotated-token")
+
+        assert await source.subject_token() == "rotated-token"
+
+    @pytest.mark.asyncio
+    async def test_runtime_error_after_construction(self, tmp_path):
+        token_file = tmp_path / "token"
+        token_file.write_text("initial-token")
+        source = FileTokenSource(token_file_path=str(token_file))
+
+        os.remove(token_file)
+
+        with pytest.raises(WorkloadIdentityRuntimeError) as exc_info:
+            await source.subject_token()
+        assert exc_info.value.source == "file"
+
+
+class TestEKSWorkloadIdentityCompat:
+    def test_is_a_workload_identity(self, tmp_path):
+        token_file = tmp_path / "token"
+        token_file.write_text("eks-token")
+
+        provider = EKSWorkloadIdentity(token_file_path=str(token_file))
+
+        assert isinstance(provider, WorkloadIdentity)
+
+    def test_does_not_discover_azure_var(self, tmp_path, monkeypatch):
+        # The deprecated EKS provider keeps the EKS-only discovery list; the
+        # AKS variable is discovered only by FileTokenSource.
+        token_file = tmp_path / "token"
+        token_file.write_text("azure-token")
+
+        for name in FileTokenSource.default_env_var_names:
+            monkeypatch.delenv(name, raising=False)
+        monkeypatch.setenv("AZURE_FEDERATED_TOKEN_FILE", str(token_file))
+
+        with pytest.raises(WorkloadIdentityConfigurationError):
+            EKSWorkloadIdentity()
+
+        source = FileTokenSource()
+        assert source.token_file_path == str(token_file)
+
+
+class TestGCPMetadataTokenSource:
+    def test_requires_audience(self):
+        with pytest.raises(WorkloadIdentityConfigurationError) as exc_info:
+            GCPMetadataTokenSource("  ")
+        assert exc_info.value.source == "gcp-metadata"
+
+    @pytest.mark.asyncio
+    async def test_request_shape(self):
+        seen = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen["path"] = request.url.path
+            seen["audience"] = request.url.params.get("audience")
+            seen["format"] = request.url.params.get("format")
+            seen["metadata_flavor"] = request.headers.get("Metadata-Flavor")
+            return httpx.Response(200, text="gcp-identity-token\n")
+
+        source = GCPMetadataTokenSource(
+            "https://zone.example.com",
+            _transport=httpx.MockTransport(handler),
+        )
+
+        token = await source.subject_token()
+
+        assert token == "gcp-identity-token"
+        assert seen["path"] == (
+            "/computeMetadata/v1/instance/service-accounts/default/identity"
+        )
+        assert seen["audience"] == "https://zone.example.com"
+        assert seen["format"] == "full"
+        assert seen["metadata_flavor"] == "Google"
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "response",
+        [
+            httpx.Response(404, text="not found"),
+            httpx.Response(200, text="  \n"),
+        ],
+        ids=["non-200 status", "empty body"],
+    )
+    async def test_runtime_error_on_failure(self, response):
+        source = GCPMetadataTokenSource(
+            "https://zone.example.com",
+            _transport=httpx.MockTransport(lambda request: response),
+        )
+
+        with pytest.raises(WorkloadIdentityRuntimeError) as exc_info:
+            await source.subject_token()
+        assert exc_info.value.source == "gcp-metadata"
+
+    @pytest.mark.asyncio
+    async def test_runtime_error_when_unreachable(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            raise httpx.ConnectError("connection refused", request=request)
+
+        source = GCPMetadataTokenSource(
+            "https://zone.example.com",
+            _transport=httpx.MockTransport(handler),
+        )
+
+        with pytest.raises(WorkloadIdentityRuntimeError) as exc_info:
+            await source.subject_token()
+        assert exc_info.value.__cause__ is not None
+
+
+class TestFlyTokenSource:
+    @pytest.mark.asyncio
+    async def test_request_shape_with_audience(self):
+        seen = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen["method"] = request.method
+            seen["path"] = request.url.path
+            seen["content_type"] = request.headers.get("Content-Type")
+            seen["body"] = request.content.decode()
+            return httpx.Response(200, text="fly-oidc-token\n")
+
+        source = FlyTokenSource(
+            audience="https://zone.example.com",
+            _transport=httpx.MockTransport(handler),
+        )
+
+        token = await source.subject_token()
+
+        assert token == "fly-oidc-token"
+        assert seen["method"] == "POST"
+        assert seen["path"] == "/v1/tokens/oidc"
+        assert seen["content_type"] == "application/json"
+        assert seen["body"] == '{"aud":"https://zone.example.com"}'
+
+    @pytest.mark.asyncio
+    async def test_empty_object_body_without_audience(self):
+        seen = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen["body"] = request.content.decode()
+            return httpx.Response(200, text="fly-oidc-token")
+
+        source = FlyTokenSource(_transport=httpx.MockTransport(handler))
+
+        await source.subject_token()
+
+        assert seen["body"] == "{}"
+
+    @pytest.mark.asyncio
+    async def test_runtime_error_on_non_200(self):
+        source = FlyTokenSource(
+            _transport=httpx.MockTransport(
+                lambda request: httpx.Response(404, text="machine not found")
+            ),
+        )
+
+        with pytest.raises(WorkloadIdentityRuntimeError) as exc_info:
+            await source.subject_token()
+        assert exc_info.value.source == "fly"
+
+    @pytest.mark.asyncio
+    async def test_runtime_error_when_socket_missing(self, tmp_path):
+        source = FlyTokenSource(socket_path=str(tmp_path / "no-such.sock"))
+
+        with pytest.raises(WorkloadIdentityRuntimeError) as exc_info:
+            await source.subject_token()
+        assert exc_info.value.__cause__ is not None
+
+    @pytest.mark.asyncio
+    async def test_real_unix_socket(self):
+        # Prove the uds wiring end to end with a minimal HTTP server on a
+        # real Unix socket. Uses tempfile.mkdtemp rather than tmp_path to
+        # stay under the platform's Unix socket path length limit.
+        socket_dir = tempfile.mkdtemp(prefix="fly")
+        socket_path = os.path.join(socket_dir, "api.sock")
+        body = b"fly-oidc-token"
+        response = (
+            b"HTTP/1.1 200 OK\r\n"
+            b"Content-Type: text/plain\r\n"
+            b"Content-Length: " + str(len(body)).encode() + b"\r\n"
+            b"Connection: close\r\n"
+            b"\r\n" + body
+        )
+
+        async def serve(reader, writer):
+            await reader.read(4096)
+            writer.write(response)
+            await writer.drain()
+            writer.close()
+
+        server = await asyncio.start_unix_server(serve, path=socket_path)
+        try:
+            source = FlyTokenSource(socket_path=socket_path)
+            assert await source.subject_token() == "fly-oidc-token"
+        finally:
+            server.close()
+            await server.wait_closed()
+            shutil.rmtree(socket_dir, ignore_errors=True)


### PR DESCRIPTION
## What

Python implementation of the [workload-identity spec](https://github.com/keycardai/keycard-sdk-spec/blob/main/specs/application-credentials/workload-identity.md) (status: Proposed, accepted in keycard-sdk-spec#39). Tracks [ECO-110](https://linear.app/keycardlabs/issue/ECO-110/python-sdk-workloadidentity-credential-subjecttokensource-workload). Mirrors the Go implementation ([go-sdk#31](https://github.com/keycardai/go-sdk/pull/31)) with the same conformance table.

One generic `WorkloadIdentity` credential owns the invariant exchange contract: jwt-bearer client assertion, no Basic auth, fresh fetch on every exchange, no caching. The only per-platform code is a one-method protocol:

```python
class IdentityTokenSource(Protocol):
    async def identity_token(self) -> str: ...
```

**Built-in sources (named by mechanism, not platform), the spec's complete v1 set:**
- `FileTokenSource`: projected token files. Covers EKS, AKS (`AZURE_FEDERATED_TOKEN_FILE` is in the default discovery list), and any Kubernetes projected service-account token.
- `GCPMetadataTokenSource`: GCP metadata identity endpoint (`?audience=&format=full` + `Metadata-Flavor: Google`). Covers GKE, GCE, Cloud Run.
- `FlyTokenSource`: POST `/v1/tokens/oidc` over the `/.fly/api` Unix socket via httpx uds transport, audience in the JSON body.
- Bare callable (sync or async) accepted anywhere a source is.

**client_id (KEP 108):** optional `client_id` constructor argument, sent as the `client_id` form parameter alongside the assertion (the field already existed on `TokenExchangeRequest` and serializes automatically). Token-federation application credentials are resolved by it; legacy token credentials don't need it.

**Back-compat:** `EKSWorkloadIdentity` becomes a deprecated subclass of `WorkloadIdentity` that wraps its existing discovery/validation/read logic as a source: unchanged signature, EKS-only env discovery (a test pins that it does NOT discover the Azure variable), and unchanged error types. `EKSWorkloadIdentity{Configuration,Runtime}Error` are now subclasses of the new `WorkloadIdentity{Configuration,Runtime}Error` (which carry a `source` attribute), so existing `except` clauses keep working and new code can catch the generic types. All 30 pre-existing credential tests pass unchanged.

**Divergence note vs Go, deliberate:** Go's error aliasing makes EKS and generic errors the same type; Python uses subclassing because the EKS errors carry a richer message shape. Both satisfy the spec's "aliases or subclasses" contract.

## Testing

Conformance tests per the spec's Testing table: fake/callable sources asserting the exact exchange-request shape, no-caching via call counter, cause chaining (`__cause__`), tmp files + monkeypatched env for every discovery variable, `httpx.MockTransport` for the GCP and Fly request shapes and failure paths, plus one real Unix-socket server test proving the uds wiring end to end. `ruff check` clean, full package suite 332 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
