### PR TITLE
fix(keycardai-starlette): return 401/503 (not 500) for JWKS errors

### DIFF
--- a/packages/starlette/src/keycardai/starlette/middleware/bearer.py
+++ b/packages/starlette/src/keycardai/starlette/middleware/bearer.py
@@ -14,7 +14,15 @@ from collections.abc import Sequence
 
 from pydantic import AnyHttpUrl
 
-from keycardai.oauth.exceptions import InvalidTokenError
+from keycardai.oauth.exceptions import (
+    InvalidTokenError,
+    JWKSError,
+    JWKSKeyNotFoundError,
+)
+from keycardai.oauth.server.exceptions import (
+    JWKSDiscoveryError,
+    JWKSUriValidationError,
+)
 from keycardai.oauth.server.verifier import TokenVerifier
 from starlette.authentication import (
     AuthCredentials,
@@ -223,6 +231,24 @@ class KeycardAuthBackend(AuthenticationBackend):
             raise KeycardAuthError(
                 "invalid_token", "Token verification failed"
             ) from e
+        except JWKSKeyNotFoundError as e:
+            # Forged token, or a valid token whose signing key rotated out of
+            # the JWKS: the resource server cannot validate it. RFC 6750
+            # invalid_token so the client re-runs authorization instead of
+            # seeing a 500.
+            raise KeycardAuthError(
+                "invalid_token", "Unable to verify token signing key"
+            ) from e
+        except (JWKSError, JWKSDiscoveryError, JWKSUriValidationError) as e:
+            # JWKS fetch or issuer discovery failed: verification could not
+            # complete for a server-side reason (unreachable zone, non-2xx
+            # JWKS, cross-origin jwks_uri). Signal a retryable 503 rather than
+            # letting the exception escape to a 500 with a stack trace.
+            raise KeycardAuthError(
+                "temporarily_unavailable",
+                "Unable to reach the authorization server to verify the token",
+                status_code=503,
+            ) from e
 
         resource_server_url = _get_oauth_protected_resource_url(conn)
         user = KeycardUser(
@@ -250,6 +276,13 @@ def _build_unauthorized_response(
     anonymous). The ``resource_metadata=`` URL is computed from the request
     per RFC 9728.
     """
+    if status_code >= 500:
+        # Verification could not complete (e.g. the JWKS endpoint was
+        # unreachable). This is not a challenge the client can satisfy by
+        # re-authenticating, so return a small body and no WWW-Authenticate
+        # header. Never leak the underlying exception.
+        return Response(content=description or "Service Unavailable", status_code=status_code)
+
     resource_metadata = _get_oauth_protected_resource_url(conn)
     response = Response(
         content="Unauthorized" if status_code == 401 else "Forbidden",

--- a/packages/starlette/src/keycardai/starlette/middleware/bearer.py
+++ b/packages/starlette/src/keycardai/starlette/middleware/bearer.py
@@ -244,6 +244,12 @@ class KeycardAuthBackend(AuthenticationBackend):
             # complete for a server-side reason (unreachable zone, non-2xx
             # JWKS, cross-origin jwks_uri). Signal a retryable 503 rather than
             # letting the exception escape to a 500 with a stack trace.
+            #
+            # This bucket intentionally lists the named discovery/fetch classes,
+            # not the OAuthServerError base. Config and cache faults
+            # (VerifierConfigError, CacheError) are not per-request failures, so
+            # they stay on the unexpected-error path (500) instead of a 503 that
+            # would falsely advertise the fault as transient.
             raise KeycardAuthError(
                 "temporarily_unavailable",
                 "Unable to reach the authorization server to verify the token",

--- a/packages/starlette/tests/keycardai/starlette/test_provider.py
+++ b/packages/starlette/tests/keycardai/starlette/test_provider.py
@@ -9,11 +9,16 @@ from starlette.middleware.authentication import AuthenticationMiddleware
 from starlette.requests import HTTPConnection, Request
 from starlette.testclient import TestClient
 
-from keycardai.oauth.exceptions import InvalidTokenError
+from keycardai.oauth.exceptions import (
+    InvalidTokenError,
+    JWKSFetchError,
+    JWKSKeyNotFoundError,
+)
 from keycardai.oauth.server import AccessContext
 from keycardai.oauth.server.credentials import ClientSecret
 from keycardai.oauth.server.exceptions import (
     AuthProviderConfigurationError,
+    JWKSDiscoveryError,
     MissingAccessContextError,
 )
 from keycardai.starlette import (
@@ -324,6 +329,71 @@ class TestKeycardAuthBackend:
         challenge = response.headers.get("WWW-Authenticate", "")
         assert 'Bearer error="invalid_token"' in challenge
         assert "resource_metadata=" in challenge
+
+    def test_jwks_key_not_found_returns_401_challenge(self):
+        """A forged/rotated kid (JWKSKeyNotFoundError) is a 401, not a 500."""
+        provider = AuthProvider(
+            zone_id="test-zone",
+            application_credential=ClientSecret(("cid", "csec")),
+        )
+        verifier = MagicMock(
+            enable_multi_zone=False,
+            verify_token=AsyncMock(
+                side_effect=JWKSKeyNotFoundError("Key ID 'abc' not found")
+            ),
+        )
+        provider.get_token_verifier = MagicMock(return_value=verifier)  # type: ignore[method-assign]
+
+        app = FastAPI()
+        provider.install(app)
+
+        @app.get("/api/me")
+        @requires("authenticated")
+        async def me(request: Request):
+            return {"ok": True}
+
+        client = TestClient(app, raise_server_exceptions=False)
+        response = client.get(
+            "/api/me", headers={"Authorization": "Bearer forged-token"}
+        )
+        assert response.status_code == 401
+        challenge = response.headers.get("WWW-Authenticate", "")
+        assert 'Bearer error="invalid_token"' in challenge
+        assert "resource_metadata=" in challenge
+
+    @pytest.mark.parametrize(
+        "error",
+        [
+            JWKSFetchError("JWKS endpoint returned status 503"),
+            JWKSDiscoveryError("https://zone.example.com", "test-zone"),
+        ],
+    )
+    def test_jwks_fetch_or_discovery_failure_returns_503(self, error):
+        """A JWKS/discovery outage is a retryable 503, not a 500 with a leak."""
+        provider = AuthProvider(
+            zone_id="test-zone",
+            application_credential=ClientSecret(("cid", "csec")),
+        )
+        verifier = MagicMock(
+            enable_multi_zone=False,
+            verify_token=AsyncMock(side_effect=error),
+        )
+        provider.get_token_verifier = MagicMock(return_value=verifier)  # type: ignore[method-assign]
+
+        app = FastAPI()
+        provider.install(app)
+
+        @app.get("/api/me")
+        @requires("authenticated")
+        async def me(request: Request):
+            return {"ok": True}
+
+        client = TestClient(app, raise_server_exceptions=False)
+        response = client.get(
+            "/api/me", headers={"Authorization": "Bearer valid-looking-token"}
+        )
+        assert response.status_code == 503
+        assert "WWW-Authenticate" not in response.headers
 
     def test_keycard_auth_error_carries_oauth_metadata(self):
         exc = KeycardAuthError("invalid_token", "Token verification failed")


### PR DESCRIPTION
Python-side of keycardai/typescript-sdk#119.

## Problem

`KeycardAuthBackend.authenticate()` (`packages/starlette/src/keycardai/starlette/middleware/bearer.py`) caught only `InvalidTokenError`. JWKS errors are a separate tree — `JWKSError`/`JWKSKeyNotFoundError` extend `OAuthError(Exception)`; `JWKSDiscoveryError`/`JWKSUriValidationError` extend `OAuthServerError(Exception)` — none of which is `InvalidTokenError` or a Starlette `AuthenticationError`.

So they escaped `AuthenticationMiddleware` → `ServerErrorMiddleware` → **HTTP 500 with no `WWW-Authenticate`**. A token whose `kid` is absent from the JWKS (forged, or rotated out), or an unreachable/non-2xx JWKS or discovery endpoint, all returned 500 instead of a clean 401/503.

## Fix

Map the JWKS error classes at the auth boundary:

| Error | Response |
| --- | --- |
| `JWKSKeyNotFoundError` | **401** `invalid_token` + `WWW-Authenticate` challenge (client re-runs authorization) |
| `JWKSError` / `JWKSDiscoveryError` / `JWKSUriValidationError` | **503**, small body |

`_build_unauthorized_response` now emits a bare 503 body with **no** `WWW-Authenticate` header for 5xx — that challenge isn't one a client can satisfy by re-authenticating.

Errors outside these classes are unchanged: they remain genuine unexpected errors and are not swallowed.

## Tests

Added to `test_provider.py`: `JWKSKeyNotFoundError` → 401 challenge; `JWKSFetchError` / `JWKSDiscoveryError` (parametrized) → 503 with no challenge header. 46/46 green.

## Parity

Companion PR fixes the TypeScript SDK (keycardai/typescript-sdk#123). The Go SDK is not affected (its verifier funnels all key-resolution failures into `InvalidTokenError` and the middleware has a catch-all default).