### PR TITLE
ci: fast-forward main when the bump PR merge is refused

### DIFF
--- a/scripts/bump_package.py
+++ b/scripts/bump_package.py
@@ -391,7 +391,7 @@ def checks_green(pr_data: dict) -> bool:
     return True
 
 
-def wait_for_pr_merge(pr_number: int, timeout_seconds: int = 1800) -> str | None:
+def wait_for_pr_merge(repo: str, pr_number: int, timeout_seconds: int = 1800) -> str | None:
     """Poll the PR until it merges. Returns the merge commit SHA on main.
 
     Fails if the PR is closed without merging or if the timeout elapses.
@@ -410,7 +410,7 @@ def wait_for_pr_merge(pr_number: int, timeout_seconds: int = 1800) -> str | None
                 "view",
                 str(pr_number),
                 "--json",
-                "state,mergeCommit,statusCheckRollup",
+                "state,mergeCommit,statusCheckRollup,headRefOid",
             ]
         )
         if exit_code != 0:
@@ -445,7 +445,10 @@ def wait_for_pr_merge(pr_number: int, timeout_seconds: int = 1800) -> str | None
 
         if state == "OPEN" and direct_merge_attempts < 3 and checks_green(data):
             # Auto-merge waits for requirements the app is entitled to bypass
-            # (required reviews); bypass only applies to an explicit merge.
+            # (required reviews), and the merge API does not exercise ruleset
+            # bypass either; ref updates do. Try the merge for the clean PR
+            # timeline, then fall back to fast-forwarding main to the PR head,
+            # which GitHub records as merging the PR.
             direct_merge_attempts += 1
             exit_code, _, stderr = run_command(
                 ["gh", "pr", "merge", str(pr_number), "--squash"]
@@ -453,10 +456,31 @@ def wait_for_pr_merge(pr_number: int, timeout_seconds: int = 1800) -> str | None
             if exit_code == 0:
                 print(f"Merged PR #{pr_number} directly as the bypass actor.")
             else:
-                print(
-                    f"Direct merge attempt {direct_merge_attempts} refused; "
-                    f"auto-merge stays armed: {stderr.strip()[:200]}"
-                )
+                print(f"Direct merge refused: {stderr.strip()[:200]}")
+                head_sha = data.get("headRefOid")
+                if head_sha:
+                    exit_code, _, stderr = run_command(
+                        [
+                            "gh",
+                            "api",
+                            "-X",
+                            "PATCH",
+                            f"repos/{repo}/git/refs/heads/main",
+                            "-f",
+                            f"sha={head_sha}",
+                        ]
+                    )
+                    if exit_code == 0:
+                        print(
+                            f"Fast-forwarded main to {head_sha[:8]}; "
+                            f"PR #{pr_number} will be marked merged."
+                        )
+                    else:
+                        print(
+                            f"Fast-forward attempt {direct_merge_attempts} failed "
+                            f"(main may have moved); auto-merge stays armed: "
+                            f"{stderr.strip()[:200]}"
+                        )
 
         time.sleep(30)
 
@@ -540,7 +564,7 @@ def bump_package(package_name: str, package_dir: str) -> bool:
     if pr_number is None:
         return False
 
-    merge_sha = wait_for_pr_merge(pr_number)
+    merge_sha = wait_for_pr_merge(repo, pr_number)
     if merge_sha is None:
         return False
 


### PR DESCRIPTION
## What

Third act of the bump saga. #194's direct merge deployed and ran, and GitHub refused it: `base branch policy prohibits the merge` ([run 29761405739](https://github.com/keycardai/python-sdk/actions/runs/29761405739), PR #200 sat open and 0.21.1 stalled).

The evidence says the ruleset bypass (`keycard-gh-workflows-access`, actor 2798702, bypassMode always, per `keycardlabs/infra` Pulumi) covers **ref pushes** but the **PR merge API doesn't exercise it**: the same app direct-pushes bump commits to go-sdk main, which the ruleset's pull_request rule would otherwise forbid, while its merge calls here get refused.

So: when the direct merge is refused, fast-forward `refs/heads/main` to the PR head via the refs API (force=false, so it only succeeds when main hasn't moved). GitHub marks the PR merged and the existing tag step proceeds at that SHA. Auto-merge stays armed and the #194 recovery pre-check still backstops any remaining stall.

Ordering of fallbacks per green-checks poll cycle (max 3): merge API → ref fast-forward → keep waiting.

Twin PR in typescript-sdk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)