### PR TITLE
Raise mcp & starlette dependency floors so GHSA fixes reach consumers

### DIFF
--- a/packages/mcp/pyproject.toml
+++ b/packages/mcp/pyproject.toml
@@ -9,7 +9,7 @@ authors = [{ name = "Keycard", email = "support@keycard.ai" }]
 dependencies = [
     "keycardai-oauth>=0.9.0",
     "keycardai-starlette>=0.6.0",
-    "mcp>=1.13.1",
+    "mcp>=1.28.1",
     "pydantic>=2.11.7",
     "httpx>=0.27.2",
     "nanoid>=2.0.0",

--- a/packages/starlette/pyproject.toml
+++ b/packages/starlette/pyproject.toml
@@ -8,7 +8,7 @@ license = { text = "MIT" }
 authors = [{ name = "Keycard", email = "support@keycard.ai" }]
 dependencies = [
     "keycardai-oauth>=0.13.0",
-    "starlette>=0.47.3",
+    "starlette>=1.0.1",
     "pydantic>=2.11.7",
     "httpx>=0.27.2",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -2368,7 +2368,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.11.7" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8.4.1" },
     { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=1.1.0" },
-    { name = "starlette", specifier = ">=0.47.3" },
+    { name = "starlette", specifier = ">=1.0.1" },
 ]
 provides-extras = ["test"]
 

--- a/uv.lock
+++ b/uv.lock
@@ -2263,7 +2263,7 @@ requires-dist = [
     { name = "keycardai-starlette", editable = "packages/starlette" },
     { name = "langchain", marker = "extra == 'test'", specifier = ">=1.0.5" },
     { name = "langchain-openai", marker = "extra == 'test'", specifier = ">=1.0.2" },
-    { name = "mcp", specifier = ">=1.13.1" },
+    { name = "mcp", specifier = ">=1.28.1" },
     { name = "nanoid", specifier = ">=2.0.0" },
     { name = "nest-asyncio", marker = "extra == 'crewai'", specifier = ">=1.6.0" },
     { name = "openai-agents", marker = "extra == 'test'", specifier = ">=0.5.1" },


### PR DESCRIPTION
> [!IMPORTANT]
> **Merge-commit this PR, do NOT squash.** It carries two separately-released packages (`keycardai-mcp` and `keycardai-starlette`), one scoped commit each. Squashing collapses to a single subject, so only one package's release would fire. A merge commit preserves both `fix(...)` commits so both release.

## Why

The Socket security PRs only edit `uv.lock`, which is **not published to PyPI**. Consumers resolve transitive deps against the declared floors in `pyproject.toml`, so a lock-only bump leaves those floors stale and lets consumers pull vulnerable versions **through our packages**. An audit of floor-vs-lock drift across all direct deps found two such gaps (both HIGH):

### `keycardai-mcp`: `mcp` `>=1.13.1` → `>=1.28.1`
Floor still allowed versions vulnerable to three HIGH advisories fixed in `mcp` 1.28.1:

| Advisory | Issue | First patched |
| --- | --- | --- |
| GHSA-jpw9-pfvf-9f58 | HTTP transports serve session requests without verifying the authenticated principal (auth bypass) | 1.27.2 |
| GHSA-hvrp-rf83-w775 | experimental task handlers allow cross-client task access | 1.27.2 |
| GHSA-vj7q-gjh5-988w | WebSocket transport missing Host/Origin validation | 1.28.1 |

Minor bump within `mcp` 1.x; the lock already resolves 1.28.1.

### `keycardai-starlette`: `starlette` `>=0.47.3` → `>=1.0.1`
Socket PR #126 (May) patched the lock to starlette 1.0.1 for **GHSA-86qp-5c8j-p5mr** (missing Host-header validation poisons `request.url.path`), but the floor stayed `>=0.47.3`, still allowing vulnerable 0.47.3–1.0.0. Starlette **never backported** the fix to the 0.x line (patched only in 1.0.1), so `>=1.0.1` is the minimum non-vulnerable floor. This **drops starlette-0.x support** — acceptable for a 0.x alpha package, and our code already runs/tests against starlette 1.x (lock resolves 1.3.1; provider tests green).

## Verification
`uv sync --all-packages --all-extras --frozen` consistent for both; `keycardai-starlette` provider tests pass on the locked starlette 1.3.1.

## Not included
`idna` (GHSA-65pc, #125) is transitive with no floor of ours to raise — lock-only was correct there. `joserfc` floor was already raised to `>=1.6.8` in #195.